### PR TITLE
Fix adapative_export image name in vizier releases

### DIFF
--- a/k8s/vizier/BUILD.bazel
+++ b/k8s/vizier/BUILD.bazel
@@ -23,6 +23,7 @@ load("//bazel:kustomize.bzl", "kustomize_build")
 package(default_visibility = ["//visibility:public"])
 
 VIZIER_IMAGE_TO_LABEL = {
+    "$(IMAGE_PREFIX)/vizier-adaptive_export_image:$(BUNDLE_VERSION)": "//src/vizier/services/adaptive_export:adaptive_export_image",
     "$(IMAGE_PREFIX)/vizier-cert_provisioner_image:$(BUNDLE_VERSION)": "//src/utils/cert_provisioner:cert_provisioner_image",
     "$(IMAGE_PREFIX)/vizier-cloud_connector_server_image:$(BUNDLE_VERSION)": "//src/vizier/services/cloud_connector:cloud_connector_server_image",
     "$(IMAGE_PREFIX)/vizier-kelvin_image:$(BUNDLE_VERSION)": "//src/vizier/services/agent/kelvin:kelvin_image",

--- a/k8s/vizier/bootstrap/adaptive_export_deployment.yaml
+++ b/k8s/vizier/bootstrap/adaptive_export_deployment.yaml
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   name: adaptive-export
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       name: adaptive-export


### PR DESCRIPTION
Summary: Fix adapative_export image name in vizier releases

Running px deploy with k8sstormcenter Pixie releases fails because the Vizier manifests reference an invalid image for adaptive_export (missing the `ghcr.io/k8sstormcenter` prefix). This fixes the image name and deploys it with 0 replicas to get a working vizier on initial `px deploy`.

The replica change will be reverted once we have the system working end to end on a fresh deployment

Relevant Issues: N/A

Type of change: /kind bugfix

Test Plan: Inspected vizier manifests from a broken release