### PR TITLE
Graduate release files from copybara ignored_dirs

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -35,32 +35,32 @@ jobs:
     with:
       image-base-name: "dev_image_with_extras"
       ref: ${{ needs.env-protect-setup.outputs.ref }}
-  # clang-tidy:
-  #   runs-on: oracle-vm-16cpu-64gb-x86-64
-  #   needs: [authorize, env-protect-setup, get-dev-image]
-  #   container:
-  #     image: ${{ needs.get-dev-image.outputs.image-with-tag }}
-  #   steps:
-  #   - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
-  #     with:
-  #       fetch-depth: 0
-  #       ref: ${{ needs.env-protect-setup.outputs.ref }}
-  #   - name: Add pwd to git safe dir
-  #     run: git config --global --add safe.directory `pwd`
-  #   - name: get bazel config
-  #     uses: ./.github/actions/bazelrc
-  #     with:
-  #       BB_API_KEY: ${{ secrets.BB_IO_API_KEY }}
-  #   - name: Save Diff Info
-  #     run: ./ci/save_diff_info.sh
-  #   - name: Run Clang Tidy
-  #     shell: bash
-  #     run: |
-  #       diff_file="diff_origin_main_cc"
-  #       if [[ "${{ github.event_name }}" == "push" ]] || [[ "${{ github.event_name }}" == "schedule" ]]; then
-  #         diff_file="diff_head_cc"
-  #       fi
-  #       ./ci/run_clang_tidy.sh -f "${diff_file}"
+  clang-tidy:
+    runs-on: oracle-vm-16cpu-64gb-x86-64
+    needs: [authorize, env-protect-setup, get-dev-image]
+    container:
+      image: ${{ needs.get-dev-image.outputs.image-with-tag }}
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      with:
+        fetch-depth: 0
+        ref: ${{ needs.env-protect-setup.outputs.ref }}
+    - name: Add pwd to git safe dir
+      run: git config --global --add safe.directory `pwd`
+    - name: get bazel config
+      uses: ./.github/actions/bazelrc
+      with:
+        BB_API_KEY: ${{ secrets.BB_IO_API_KEY }}
+    - name: Save Diff Info
+      run: ./ci/save_diff_info.sh
+    - name: Run Clang Tidy
+      shell: bash
+      run: |
+        diff_file="diff_origin_main_cc"
+        if [[ "${{ github.event_name }}" == "push" ]] || [[ "${{ github.event_name }}" == "schedule" ]]; then
+          diff_file="diff_head_cc"
+        fi
+        ./ci/run_clang_tidy.sh -f "${diff_file}"
   code-coverage:
     if: github.event_name == 'push'
     needs: [authorize, env-protect-setup, get-dev-image]
@@ -85,7 +85,7 @@ jobs:
       run: |
         # Github actions container runner creates a docker network without IPv6 support. We enable it manually.
         sysctl -w net.ipv6.conf.lo.disable_ipv6=0
-        ./ci/collect_coverage.sh -u -b main -c "$(git rev-parse HEAD)" -r k8sstormcenter/pixie
+        ./ci/collect_coverage.sh -u -b main -c "$(git rev-parse HEAD)" -r ${{ github.repository }}
   generate-matrix:
     needs: [authorize, env-protect-setup, get-dev-image]
     runs-on: oracle-vm-16cpu-64gb-x86-64
@@ -185,18 +185,19 @@ jobs:
       shell: bash
   build-and-test-status:
     if: always()
-    needs: [build-and-test, generate-matrix]
+    needs: [build-and-test, clang-tidy, generate-matrix]
     runs-on: ubuntu-latest
     steps:
-    - if: needs.build-and-test.result == 'success'
+    - if: needs.build-and-test.result == 'success' && needs.clang-tidy.result == 'success'
       run: echo "Build and Test complete ✓"
     - if: >
-        needs.generate-matrix.result == 'success'
+        needs.generate-matrix.result == 'success' && needs.clang-tidy.result == 'success'
         && needs.build-and-test.result == 'skipped'
       run: echo "Build and Test skipped no matrix configs generated ✓"
     - if: >
-        !(needs.build-and-test.result == 'success') &&
+        !(needs.build-and-test.result == 'success' && needs.clang-tidy.result == 'success') &&
         !(needs.generate-matrix.result == 'success' &&
+          needs.clang-tidy.result == 'success' &&
           needs.build-and-test.result == 'skipped')
       run: |
         echo "Build and Test failed"

--- a/tools/copybara/upstream_sync/copy.bara.sky
+++ b/tools/copybara/upstream_sync/copy.bara.sky
@@ -20,9 +20,20 @@ dest_repo = "git@github.com:k8sstormcenter/pixie.git"
 # Directories with fork-specific customizations that will be upstreamed separately.
 ignored_dirs = [
     ".bazelrc",      # upstream + fork only changes
-    ".github/**",    # upstream + fork only changes
+    # Release jobs (cli/cloud/operator/vizier _release.yaml) and their
+    # supporting ci/ scripts are now converged with upstream and flow
+    # through copybara. The entries below are non-release .github and ci
+    # files that are still fork-customized.
+    ".github/workflows/cacher.yaml",               # runner name
+    ".github/workflows/codeql.yaml",               # runner names
+    ".github/workflows/pr_3p_deps.yaml",           # fork removed; preserve deletion
+    ".github/workflows/pr_genfiles.yml",           # minor fork divergence
+    ".github/workflows/pr_linter.yml",             # minor fork divergence
+    ".github/workflows/release_update_docs_px_dev.yaml",
+    ".github/workflows/trivy_fs.yaml",
+    ".github/workflows/trivy_images.yaml",
     "DEVELOPMENT.md", # Should be moved to a fork only file
-    "ci/**",          # upstream
+    "ci/github/bazelrc",                           # fork-specific bazelrc REPO_URL
     "k8s/**",                          # cert-manager support (upstream)
     "scripts/create_cloud_secrets.sh", # cert-manager support (upstream)
     "skaffold/**",
@@ -91,8 +102,12 @@ ignored_dirs = [
 
 # Files/dirs that exist only in the fork and must not be deleted by copybara.
 fork_only_files = [
+    ".github/workflows/copybara_pixie_oss.yaml",
+    ".github/workflows/perf_clickhouse.yaml",
+    ".github/workflows/perf_soc_attack.yaml",
     "PLATFORM.md",
     "bazel/external/rules_docker_pusher_cfg.patch",
+    "ci/run_copybara.sh",
     "k8s/vizier/bootstrap/adaptive_export_*",
     "k8s/vizier/bootstrap/kustomization.yaml",
     "src/carnot/planner/ir/clickhouse_*",


### PR DESCRIPTION
Summary: Remove broad `.github/**` copybara exclusion

The upstream release jobs have been made copybara friendly and have been parameterized with GitHub action variables. This means that future changes to these release jobs will easily be copied downstream to avoid additional maintenance burden in the future.

This needs to be merged after https://github.com/pixie-io/pixie/pull/2363 and https://github.com/pixie-io/pixie/pull/2364

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Trigger all release builds again after merging this