### PR TITLE
vizier-release: build + publish standalone_pem image (MVP evidence source)

### DIFF
--- a/.github/workflows/vizier_release.yaml
+++ b/.github/workflows/vizier_release.yaml
@@ -15,7 +15,7 @@ jobs:
       image-base-name: "dev_image_with_extras"
   build-release:
     name: Build Release
-    runs-on: oracle-16cpu-64gb-x86-64
+    runs-on: oracle-vm-16cpu-64gb-x86-64
     needs: get-dev-image
     permissions:
       contents: read
@@ -140,7 +140,7 @@ jobs:
         git commit -s -m "Release Helm chart Vizier ${VERSION}"
         git push origin "gh-pages"
   update-gh-artifacts-manifest:
-    runs-on: oracle-8cpu-32gb-x86-64
+    runs-on: oracle-vm-16cpu-64gb-x86-64
     needs: [get-dev-image, create-github-release]
     container:
       image: ${{ needs.get-dev-image.outputs.image-with-tag }}

--- a/k8s/vizier/BUILD.bazel
+++ b/k8s/vizier/BUILD.bazel
@@ -30,6 +30,7 @@ VIZIER_IMAGE_TO_LABEL = {
     "$(IMAGE_PREFIX)/vizier-metadata_server_image:$(BUNDLE_VERSION)": "//src/vizier/services/metadata:metadata_server_image",
     "$(IMAGE_PREFIX)/vizier-pem_image:$(BUNDLE_VERSION)": "//src/vizier/services/agent/pem:pem_image",
     "$(IMAGE_PREFIX)/vizier-query_broker_server_image:$(BUNDLE_VERSION)": "//src/vizier/services/query_broker:query_broker_server_image",
+    "$(IMAGE_PREFIX)/vizier-standalone_pem_image:$(BUNDLE_VERSION)": "//src/experimental/standalone_pem:standalone_pem_image",
     "$(IMAGE_PREFIX)/vizier-vizier_updater_image:$(BUNDLE_VERSION)": "//src/utils/pixie_updater:vizier_updater_image",
 }
 

--- a/src/experimental/standalone_pem/BUILD.bazel
+++ b/src/experimental/standalone_pem/BUILD.bazel
@@ -79,6 +79,7 @@ cc_image(
     base = ":standalone_pem_base_image",
     binary = ":standalone_pem",
     visibility = [
+        "//k8s/vizier:__pkg__",
         "//src/vizier:__subpackages__",
     ],
 )


### PR DESCRIPTION
Summary: Bring the standalone_pem build into main so vizier-standalone_pem_image is reproducibly built + published by the vizier-release workflow. Two parts: (1) register the experimental standalone_pem in k8s/vizier/BUILD.bazel VIZIER_IMAGE_TO_LABEL and open its image-target visibility to //k8s/vizier (clean, upstreamable — mirrors how adaptive_export was added by ddelnano); (2) point the vizier_release workflow runs-on at the fork's self-hosted runner label oracle-vm-16cpu-64gb-x86-64 (fork-infra — flagged for maintainer review, since upstream's oracle-16cpu/oracle-8cpu labels don't exist in this fleet and jobs would otherwise queue forever). Build wiring only — no changes to the standalone_pem source. standalone_pem is the node-local evidence source dx talks to via pxapi-direct (the OOM/latency fix), so it is MVP-critical.

Relevant Issues: entlein/dx#2 (dx pxapi-direct to standalone_pem), entlein/dx#15 (standalone_pem metadata gap)

Type of change: /kind feature

Test Plan: Already validated out-of-band: the same wiring at tag release/vizier/v0.14.18-dxpoc3 (commit 41f08d19a) built + pushed ghcr.io/k8sstormcenter/vizier-standalone_pem_image:0.14.18-dxpoc3 via the vizier-release workflow on the oracle runner; deployed as a DaemonSet on a k3s PG and confirmed serving ExecuteScript on :12345. This PR moves that wiring to main; CI container-lint + genfiles validate the BUILD.bazel changes. The runner-label change is exercised by tag-triggered release builds (not PR CI).