### PR TITLE
pem: direct-query gRPC endpoint — stub + TDD contract

### DIFF
--- a/.github/workflows/vizier_release.yaml
+++ b/.github/workflows/vizier_release.yaml
@@ -140,7 +140,7 @@ jobs:
         git commit -s -m "Release Helm chart Vizier ${VERSION}"
         git push origin "gh-pages"
   update-gh-artifacts-manifest:
-    runs-on: oracle-8cpu-32gb-x86-64
+    runs-on: oracle-vm-16cpu-64gb-x86-64
     needs: [get-dev-image, create-github-release]
     container:
       image: ${{ needs.get-dev-image.outputs.image-with-tag }}

--- a/src/api/go/pxapi/opts.go
+++ b/src/api/go/pxapi/opts.go
@@ -82,3 +82,17 @@ func WithDirectCredsInsecure() ClientOption {
 		c.insecureDirect = true
 	}
 }
+
+// WithDirectTLSSkipVerify is the secure-by-default option for direct (standalone /
+// node-local PEM) connections: the transport IS TLS-encrypted, but the server cert
+// is not chain/hostname-verified. Use this instead of WithDirectCredsInsecure when
+// the direct endpoint serves TLS with a self-signed / service cert whose SAN does
+// not match the node IP (e.g. vizier-pem's direct-query port served with
+// service-tls-certs, dialed at HOST_IP). Unlike WithDisableTLSVerification it does
+// NOT require a "cluster.local" address, so it works for the node-IP direct dial.
+// Bearer creds (the minted JWT) therefore ride an encrypted channel, never plaintext.
+func WithDirectTLSSkipVerify() ClientOption {
+	return func(c *Client) {
+		c.disableTLSVerification = true
+	}
+}

--- a/src/carnot/BUILD.bazel
+++ b/src/carnot/BUILD.bazel
@@ -44,6 +44,14 @@ pl_cc_library(
             "carnot_executable.cc",
         ],
     ),
+    # entlein/dx#29 — PEM's direct_query_server.cc needs concrete Carnot +
+    # EngineState defs to compile and execute PxL on the live engine. Same
+    # access pattern //src/experimental/standalone_pem already uses.
+    visibility = [
+        "//src/carnot:__subpackages__",
+        "//src/experimental:__subpackages__",
+        "//src/vizier/services/agent/pem:__pkg__",
+    ],
     deps = [
         "//src/carnot/exec:cc_library",
         "//src/carnot/exec/ml:cc_library",

--- a/src/carnot/exec/BUILD.bazel
+++ b/src/carnot/exec/BUILD.bazel
@@ -36,6 +36,16 @@ pl_cc_library(
         "clickhouse_source_node.h",
         "exec_node.h",
         "exec_state.h",
+        # entlein/dx#29 — direct_query_server_test in
+        # //src/vizier/services/agent/pem needs LocalGRPCResultSinkServer
+        # for its Carnot fixture (same pattern as //src/carnot:carnot_test).
+        # Per-target visibility extension below keeps the rest of cc_library
+        # package-internal.
+        "local_grpc_result_server.h",
+    ],
+    visibility = [
+        "//src/carnot:__subpackages__",
+        "//src/vizier/services/agent/pem:__pkg__",
     ],
     deps = [
         "//src/carnot/carnotpb:carnot_pl_cc_proto",
@@ -61,6 +71,10 @@ pl_cc_library(
 pl_cc_test_library(
     name = "test_utils",
     hdrs = glob(["*test_utils.h"]),
+    visibility = [
+        "//src/carnot:__subpackages__",
+        "//src/vizier/services/agent/pem:__pkg__",  # entlein/dx#29 fixture
+    ],
     deps = [
         ":exec_node_test_helpers",
         "@com_github_apache_arrow//:arrow",

--- a/src/carnot/udf/BUILD.bazel
+++ b/src/carnot/udf/BUILD.bazel
@@ -19,6 +19,9 @@ load("//bazel:pl_build_system.bzl", "pl_cc_binary", "pl_cc_library", "pl_cc_test
 package(default_visibility = [
     "//src/carnot:__subpackages__",
     "//src/vizier/funcs:__subpackages__",
+    # entlein/dx#29 — PEM's direct_query_server_test builds a CarnotTest-style
+    # fixture with a udf::Registry, same pattern as //src/carnot:carnot_test.
+    "//src/vizier/services/agent/pem:__pkg__",
 ])
 
 pl_cc_library(

--- a/src/stirling/source_connectors/socket_tracer/testing/container_images/BUILD.bazel
+++ b/src/stirling/source_connectors/socket_tracer/testing/container_images/BUILD.bazel
@@ -24,29 +24,29 @@ package(default_visibility = [
 
 # Generate all Go container library permutations for supported Go versions.
 go_container_libraries(
+    bazel_sdk_versions = pl_all_supported_go_sdk_versions,
     container_type = "grpc_server",
-    bazel_sdk_versions = pl_all_supported_go_sdk_versions,
     prebuilt_container_versions = pl_go_test_versions,
 )
 
 # Stirling test cases usually test server side tracing. Therefore
 # we only need to provide the bazel SDK versions for the client containers.
 go_container_libraries(
+    bazel_sdk_versions = pl_all_supported_go_sdk_versions,
     container_type = "grpc_client",
-    bazel_sdk_versions = pl_all_supported_go_sdk_versions,
 )
 
 go_container_libraries(
-    container_type = "tls_server",
     bazel_sdk_versions = pl_all_supported_go_sdk_versions,
+    container_type = "tls_server",
     prebuilt_container_versions = pl_go_test_versions,
 )
 
 # Stirling test cases usually test server side tracing. Therefore
 # we only need to provide the bazel SDK versions for the client containers.
 go_container_libraries(
-    container_type = "tls_client",
     bazel_sdk_versions = pl_all_supported_go_sdk_versions,
+    container_type = "tls_client",
 )
 
 pl_cc_test_library(

--- a/src/utils/shared/k8s/apply.go
+++ b/src/utils/shared/k8s/apply.go
@@ -30,8 +30,8 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
-	"k8s.io/apimachinery/pkg/api/meta"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/src/utils/shared/k8s/delete.go
+++ b/src/utils/shared/k8s/delete.go
@@ -123,8 +123,8 @@ func (o *ObjectDeleter) DeleteNamespace() error {
 // groups are skipped during cluster-wide deletion sweeps because aggregated
 // servers frequently advertise the delete verb on read-only virtual resources
 // and fail the call with "operation not supported".
-func (o *ObjectDeleter) getAggregatedGroupVersions() (sets.String, error) {
-	out := sets.NewString()
+func (o *ObjectDeleter) getAggregatedGroupVersions() (sets.Set[string], error) {
+	out := sets.New[string]()
 	list, err := o.dynamicClient.Resource(apiServiceGVR).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) || meta.IsNoMatchError(err) {
@@ -173,7 +173,7 @@ func (o *ObjectDeleter) getDeletableResourceTypes() ([]string, error) {
 			if len(resource.Verbs) == 0 {
 				continue
 			}
-			if !sets.NewString(resource.Verbs...).HasAll("delete") {
+			if !sets.New[string](resource.Verbs...).HasAll("delete") {
 				continue
 			}
 			resources = append(resources, resource.Name)

--- a/src/vizier/services/agent/pem/BUILD.bazel
+++ b/src/vizier/services/agent/pem/BUILD.bazel
@@ -40,8 +40,10 @@ pl_cc_library(
         "//src/carnot:cc_library",  # Carnot, EngineState concrete defs
         "//src/carnot/carnotpb:carnot_pl_cc_proto",  # TransferResultChunkRequest
         "//src/carnot/exec:cc_library",  # LocalGRPCResultSinkServer
+        "//src/carnot/funcs:cc_library",  # Step 9: funcs::RegisterFuncsOrDie
         "//src/carnot/planner/compiler:cc_library",  # Compiler().Compile(...)
         "//src/carnot/planpb:plan_pl_cc_proto",  # planpb::Plan, OperatorType
+        "//src/carnot/udf:cc_library",  # Step 9: udf::Registry
         # Step 1 (#29): HS256 verify uses BoringSSL HMAC directly and parses
         # claims via rapidjson. cpp_jwt's own HMAC verify path calls
         # BIO_f_base64 which is in boringssl/decrepit/ — not exposed as a

--- a/src/vizier/services/agent/pem/BUILD.bazel
+++ b/src/vizier/services/agent/pem/BUILD.bazel
@@ -20,6 +20,23 @@ load("//bazel:pl_build_system.bzl", "pl_cc_binary", "pl_cc_library", "pl_cc_test
 
 package(default_visibility = ["//src/vizier:__subpackages__"])
 
+# entlein/dx#29 — compile-time kill switch for the direct-query endpoint.
+# Operators who do not want the feature available IN THE BINARY at all build
+# with `bazel build … --//src/vizier/services/agent/pem:direct_query=disabled`
+# (or equivalently `--define=PX_PEM_DIRECT_QUERY=disabled` if invoking via
+# bazel's legacy --define flag). When disabled, this propagates
+# `-DPX_PEM_DIRECT_QUERY_DISABLED` into every translation unit in cc_library;
+# direct_query_server.cc's body, pem_manager.cc's flag DEFINEs, and
+# MaybeStartDirectQueryServer's implementation are all `#ifndef`'d out, and
+# the stub class methods return UNIMPLEMENTED for any caller that still
+# routes through DirectQueryServer. The runtime flag --direct_query_enabled
+# is the soft, per-deploy toggle; this is the hard, per-build toggle. See
+# DIRECT_QUERY_SECURITY.md "Disabling the feature".
+config_setting(
+    name = "direct_query_disabled",
+    define_values = {"PX_PEM_DIRECT_QUERY": "disabled"},
+)
+
 pl_cc_library(
     name = "cc_library",
     srcs = glob(
@@ -30,6 +47,10 @@ pl_cc_library(
         ],
     ),
     hdrs = glob(["*.h"]),
+    defines = select({
+        ":direct_query_disabled": ["PX_PEM_DIRECT_QUERY_DISABLED"],
+        "//conditions:default": [],
+    }),
     deps = [
         # entlein/dx#29 direct-query server deps (direct_query_server.{h,cc}):
         "//src/api/proto/vizierpb:vizier_pl_cc_proto",

--- a/src/vizier/services/agent/pem/BUILD.bazel
+++ b/src/vizier/services/agent/pem/BUILD.bazel
@@ -33,7 +33,14 @@ pl_cc_library(
     deps = [
         # entlein/dx#29 direct-query server deps (direct_query_server.{h,cc}):
         "//src/api/proto/vizierpb:vizier_pl_cc_proto",
-        "//src/carnot:cc_library",
+        # Use //src/carnot:carnot (the public header target) rather than
+        # //src/carnot:cc_library — the impl target's visibility is limited
+        # to //src/carnot:__subpackages__ + //src/experimental:__subpackages__
+        # (which is why standalone_pem can use it but PEM can't); :carnot is
+        # explicitly opened to //src/vizier/services/agent:__subpackages__.
+        # Additional carnot sub-deps (engine_state, planner/compiler) get
+        # added as we wire the ExecuteScript impl in Step 2.
+        "//src/carnot",
         "@com_github_grpc_grpc//:grpc++",
         # existing PEM deps:
         "//src/carnot/planner/dynamic_tracing/ir/logicalpb:logical_pl_cc_proto",
@@ -59,13 +66,16 @@ pl_cc_test(
 # entlein/dx#29 — TDD contract for the PEM direct-query endpoint. dx-agent authored
 # the spec; pem-agent makes it pass (port the standalone_pem execution path + JWT
 # verify + Carnot fixture). See DIRECT_QUERY_CONTRACT.md.
+#
+# Note: pl_cc_test auto-injects //src/common/testing:cc_library for gtest/gmock,
+# so we must NOT list it explicitly here — same shape as tracepoint_manager_test
+# above (the dx-agent flagged this as a likely nit in the kickoff comment).
 pl_cc_test(
     name = "direct_query_server_test",
     srcs = ["direct_query_server_test.cc"],
     deps = [
         ":cc_library",
         "//src/api/proto/vizierpb:vizier_pl_cc_proto",
-        "//src/common/testing:cc_library",
         "@com_github_grpc_grpc//:grpc++",
     ],
 )

--- a/src/vizier/services/agent/pem/BUILD.bazel
+++ b/src/vizier/services/agent/pem/BUILD.bazel
@@ -41,7 +41,14 @@ pl_cc_library(
         # Additional carnot sub-deps (engine_state, planner/compiler) get
         # added as we wire the ExecuteScript impl in Step 2.
         "//src/carnot",
+        # Step 1 (#29): HS256 verify uses BoringSSL HMAC directly and parses
+        # claims via rapidjson. cpp_jwt's own HMAC verify path calls
+        # BIO_f_base64 which is in boringssl/decrepit/ — not exposed as a
+        # bazel target on this fork. Native HMAC is ~50 LoC vs. a boringssl
+        # patch; the mint side (test only, via cpp_jwt) still uses the lib.
+        "@boringssl//:crypto",
         "@com_github_grpc_grpc//:grpc++",
+        "@com_github_tencent_rapidjson//:rapidjson",
         # existing PEM deps:
         "//src/carnot/planner/dynamic_tracing/ir/logicalpb:logical_pl_cc_proto",
         "//src/integrations/grpc_clocksync:cc_library",
@@ -76,6 +83,7 @@ pl_cc_test(
     deps = [
         ":cc_library",
         "//src/api/proto/vizierpb:vizier_pl_cc_proto",
+        "@com_github_arun11299_cpp_jwt//:cpp_jwt",  # Step 1: MakeBearerToken mints HS256
         "@com_github_grpc_grpc//:grpc++",
     ],
 )

--- a/src/vizier/services/agent/pem/BUILD.bazel
+++ b/src/vizier/services/agent/pem/BUILD.bazel
@@ -31,6 +31,11 @@ pl_cc_library(
     ),
     hdrs = glob(["*.h"]),
     deps = [
+        # entlein/dx#29 direct-query server deps (direct_query_server.{h,cc}):
+        "//src/api/proto/vizierpb:vizier_pl_cc_proto",
+        "//src/carnot:cc_library",
+        "@com_github_grpc_grpc//:grpc++",
+        # existing PEM deps:
         "//src/carnot/planner/dynamic_tracing/ir/logicalpb:logical_pl_cc_proto",
         "//src/integrations/grpc_clocksync:cc_library",
         "//src/shared/tracepoint_translation:cc_library",
@@ -48,6 +53,20 @@ pl_cc_test(
         "//src/common/testing/event:cc_library",
         "//src/stirling/testing:stirling_mock",
         "//src/vizier/services/agent/shared/manager:test_utils",
+    ],
+)
+
+# entlein/dx#29 — TDD contract for the PEM direct-query endpoint. dx-agent authored
+# the spec; pem-agent makes it pass (port the standalone_pem execution path + JWT
+# verify + Carnot fixture). See DIRECT_QUERY_CONTRACT.md.
+pl_cc_test(
+    name = "direct_query_server_test",
+    srcs = ["direct_query_server_test.cc"],
+    deps = [
+        ":cc_library",
+        "//src/api/proto/vizierpb:vizier_pl_cc_proto",
+        "//src/common/testing:cc_library",
+        "@com_github_grpc_grpc//:grpc++",
     ],
 )
 

--- a/src/vizier/services/agent/pem/BUILD.bazel
+++ b/src/vizier/services/agent/pem/BUILD.bazel
@@ -33,14 +33,15 @@ pl_cc_library(
     deps = [
         # entlein/dx#29 direct-query server deps (direct_query_server.{h,cc}):
         "//src/api/proto/vizierpb:vizier_pl_cc_proto",
-        # Use //src/carnot:carnot (the public header target) rather than
-        # //src/carnot:cc_library — the impl target's visibility is limited
-        # to //src/carnot:__subpackages__ + //src/experimental:__subpackages__
-        # (which is why standalone_pem can use it but PEM can't); :carnot is
-        # explicitly opened to //src/vizier/services/agent:__subpackages__.
-        # Additional carnot sub-deps (engine_state, planner/compiler) get
-        # added as we wire the ExecuteScript impl in Step 2.
+        # Use //src/carnot:carnot (the public header target) for forward decls
+        # in direct_query_server.h. Step 2 (#29) needs concrete types — pull
+        # additional carnot sub-targets exposed via the fork's PEM visibility:
         "//src/carnot",
+        "//src/carnot:cc_library",  # Carnot, EngineState concrete defs
+        "//src/carnot/carnotpb:carnot_pl_cc_proto",  # TransferResultChunkRequest
+        "//src/carnot/exec:cc_library",  # LocalGRPCResultSinkServer
+        "//src/carnot/planner/compiler:cc_library",  # Compiler().Compile(...)
+        "//src/carnot/planpb:plan_pl_cc_proto",  # planpb::Plan, OperatorType
         # Step 1 (#29): HS256 verify uses BoringSSL HMAC directly and parses
         # claims via rapidjson. cpp_jwt's own HMAC verify path calls
         # BIO_f_base64 which is in boringssl/decrepit/ — not exposed as a
@@ -48,6 +49,7 @@ pl_cc_library(
         # patch; the mint side (test only, via cpp_jwt) still uses the lib.
         "@boringssl//:crypto",
         "@com_github_grpc_grpc//:grpc++",
+        "@com_github_rlyeh_sole//:sole",  # sole::uuid4 for query_id
         "@com_github_tencent_rapidjson//:rapidjson",
         # existing PEM deps:
         "//src/carnot/planner/dynamic_tracing/ir/logicalpb:logical_pl_cc_proto",
@@ -83,8 +85,16 @@ pl_cc_test(
     deps = [
         ":cc_library",
         "//src/api/proto/vizierpb:vizier_pl_cc_proto",
+        # Step 2b (#29) — Carnot exec fixture for ValidToken_TrivialQuery_StreamsRows
+        "//src/carnot",
+        "//src/carnot:cc_library",
+        "//src/carnot/exec:cc_library",  # LocalGRPCResultSinkServer
+        "//src/carnot/funcs:cc_library",  # RegisterFuncsOrDie
+        "//src/carnot/udf:cc_library",  # udf::Registry
+        "//src/table_store:cc_library",
         "@com_github_arun11299_cpp_jwt//:cpp_jwt",  # Step 1: MakeBearerToken mints HS256
         "@com_github_grpc_grpc//:grpc++",
+        "@com_github_rlyeh_sole//:sole",
     ],
 )
 

--- a/src/vizier/services/agent/pem/DIRECT_QUERY_CONTRACT.md
+++ b/src/vizier/services/agent/pem/DIRECT_QUERY_CONTRACT.md
@@ -81,7 +81,7 @@ addr is a one-line switch — add `DX_BENCH=pemdirect` selecting
 JWT mint + `WithBearerAuth` + `WithDisableTLSVerification` path proven against the
 broker. dx-agent adds this once #29's endpoint is live; no PEM-side work needed for it.
 
-## Done = 
+## Done =
 
 `direct_query_server_test.cc` green under `bazel test`, PEM image builds via the
 vizier-release workflow, and a live PG shows dx (`DX_BENCH=pemdirect`) ruling in the

--- a/src/vizier/services/agent/pem/DIRECT_QUERY_CONTRACT.md
+++ b/src/vizier/services/agent/pem/DIRECT_QUERY_CONTRACT.md
@@ -1,0 +1,88 @@
+# PEM direct-query gRPC endpoint — contract (entlein/dx#29)
+
+**Status:** stub PR. dx-agent owns this contract + the dx-side integration; the
+**pem-agent** (on a bazel-capable build VM) implements the C++ to make the TDD
+targets in `direct_query_server_test.cc` pass.
+
+## Why
+
+Today dx reads evidence by querying the in-cluster **vizier-query-broker** directly
+(entlein/dx#28, live). That works and is the MVP path. #29 adds the *durable
+per-node* path: make the **normal `vizier-pem`** itself serve `ExecuteScript`
+directly over gRPC, so dx on each node can query its node-local PEM with no broker
+hop and no cloud dependency.
+
+This is the capability the **experimental `standalone_pem`** already proved
+(`src/experimental/standalone_pem/vizier_server.h` — `px::vizier::agent::VizierServer`
+implementing `api::vizierpb::VizierService::ExecuteScript` against a local Carnot).
+The two differences for the real PEM:
+
+1. **Metadata-connected.** The normal PEM has the metadata service, so per-pod PxL
+   filters (`df[df.ctx['pod'] == ...]`) resolve — the gap that made standalone_pem
+   return empty per-pod results (old #15). Reuse the PEM's existing Carnot +
+   table_store + metadata state; do **not** stand up a second Carnot.
+2. **Authenticated.** standalone_pem was insecure (`WithDirectCredsInsecure`). The
+   real PEM is in `pl` and must require a **valid cluster service JWT** (the same
+   `jwt-signing-key` dx already mints with — see entlein/dx `cmd/dx-daemon/pxbroker.go`).
+
+## The endpoint
+
+- Service: `px.api.vizierpb.VizierService` (the generated gRPC service).
+- Method implemented: **`ExecuteScript`** (server-streaming). Mutations/tracepoints
+  are **out of scope** for #29 — return `UNIMPLEMENTED` for `req.mutation()==true`.
+  (standalone_pem handles mutations; the dx read path never mutates.)
+- Transport: gRPC over TLS. TLS may use the in-cluster self-signed CA (dx sets
+  `PX_DISABLE_TLS=1` to skip-verify, matching the broker path).
+
+## Config (flags / env) — gated OFF by default
+
+| flag / env                          | default | meaning                                            |
+|-------------------------------------|---------|----------------------------------------------------|
+| `--direct_query_enabled` / `PL_PEM_DIRECT_QUERY_ENABLED` | `false` | master switch; when false the port is never opened |
+| `--direct_query_port` / `PL_PEM_DIRECT_QUERY_PORT`       | `50305` | gRPC listen port for the direct-query service      |
+| `--direct_query_jwt_signing_key` / `PL_JWT_SIGNING_KEY`  | `""`    | HMAC key the bearer JWT must verify against         |
+
+Default-off so existing PEM deployments are byte-for-byte unchanged until opted in.
+
+## Auth contract
+
+Every `ExecuteScript` call MUST present `authorization: Bearer <jwt>` metadata.
+The JWT is verified with `PL_JWT_SIGNING_KEY` and must:
+- have a valid signature (HS256) against the signing key,
+- be unexpired (`exp` in the future),
+- carry a service/audience claim acceptable to vizier (dx mints
+  `GenerateJWTForService("dx", "vizier")` — see `src/shared/services/utils`).
+
+Missing/invalid/expired token → `grpc::StatusCode::UNAUTHENTICATED`. No token must
+ever fall through to query execution.
+
+## Behavioral contract (the executable spec → `direct_query_server_test.cc`)
+
+1. **flag-off → no listener.** With `direct_query_enabled=false`, nothing listens on
+   the port; the PEM starts exactly as today.
+2. **flag-on → serves ExecuteScript.** With it enabled + a signing key set, a gRPC
+   client with a valid bearer JWT gets a streamed response (status OK) for a trivial
+   PxL (e.g. `import px; px.display(px.DataFrame('http_events'))`).
+3. **auth required.** Same call with (a) no token, (b) a token signed by the wrong
+   key, (c) an expired token → each `UNAUTHENTICATED`, no rows.
+4. **metadata-connected filter.** A PxL with a per-pod filter returns only that pod's
+   rows (proves the metadata gap #15 is closed on the real PEM). May be an
+   integration test tagged `requires_metadata` if a unit Carnot fixture can't supply
+   pod context.
+5. **mutation rejected.** `req.mutation()==true` → `UNIMPLEMENTED` (scope guard).
+6. **no regression.** The existing PEM agent registration / Carnot / Stirling path is
+   unchanged when the flag is off (assert via the existing PEM smoke/unit tests).
+
+## dx-side integration (owned by dx-agent — informational)
+
+dx already has the client: `cmd/dx-daemon/pxbroker.go`. Pointing it at a per-PEM
+addr is a one-line switch — add `DX_BENCH=pemdirect` selecting
+`DX_PEM_DIRECT_ADDR=<HOST_IP>:50305` (HOST_IP via downward API), reusing the exact
+JWT mint + `WithBearerAuth` + `WithDisableTLSVerification` path proven against the
+broker. dx-agent adds this once #29's endpoint is live; no PEM-side work needed for it.
+
+## Done = 
+
+`direct_query_server_test.cc` green under `bazel test`, PEM image builds via the
+vizier-release workflow, and a live PG shows dx (`DX_BENCH=pemdirect`) ruling in the
+log4shell e2e off the node-local PEM with the same verdict it gets via the broker.

--- a/src/vizier/services/agent/pem/DIRECT_QUERY_SECURITY.md
+++ b/src/vizier/services/agent/pem/DIRECT_QUERY_SECURITY.md
@@ -80,7 +80,7 @@ covers the gRPC/PxL surface; this doc covers crypto + key handling only.
 |---|---|
 | **Key compromise.** If `pl-cluster-secrets/jwt-signing-key` leaks, an attacker can mint valid tokens for kelvin / query-broker / direct-query at will. | Same threat model as the entire in-cluster service mesh. Out-of-band protections (RBAC on the Secret, sealed-secrets/SOPS at rest, key rotation) are the appropriate controls. |
 | **Token replay within the validity window.** A captured valid token is replayable until `exp`. | The `jti` claim is minted by `GenerateServiceToken` but the direct-query verifier does NOT track it (no nonce store). Defensive choice: tokens are short-lived (60s in `GenerateServiceToken`) and in-cluster traffic is TLS-encapsulated, so capture surface is small. If/when we need anti-replay, add a sliding `jti` LRU. |
-| **Confidentiality of the PxL query body.** The JWT only authenticates the caller; the gRPC channel itself carries the script. | Channel TLS is the PixieTLS in `k8s/vizier/base/*` manifests; direct-query inherits it via the `pem_daemonset.yaml` cert mounts (or `InsecureServerCredentials` when explicitly disabled for soak/dev — never in production). |
+| **Confidentiality of the PxL query body** + **JWT exposure on the wire**. The JWT only authenticates the caller; the gRPC channel itself carries both the bearer header and the script body. | The :50305 listener uses **cluster-default TLS via `SSL::DefaultGRPCServerCreds()`** (`pem_manager.cc:MaybeStartDirectQueryServer`), reusing the same `tls_ca_crt` + `client_tls_cert` + `client_tls_key` mounts kelvin / metadata / the broker use. Plaintext fallback only when the operator sets `PL_DISABLE_SSL=1` — that is an EXPLICIT dev/soak choice, not a silent default. See "Transport" below. |
 | **PEM-level authorization (who can run what PxL).** Any valid token can run any read-only PxL. | Mutations are rejected at the scope guard (`req.mutation() == true → UNIMPLEMENTED`). For read-only queries, the contract is "anyone the cluster trusts to mint a JWT can read PEM data" — same as kelvin's contract. |
 | **Cross-tenant isolation in a multi-cluster cloud.** | Out of scope: this is a per-cluster service-to-service token; cross-cluster auth is the cloud's job. |
 | **Network-level access control to `:50305`.** | `NetworkPolicy` in the manifest is the right place (out-of-scope for this PR; tracked as a future hardening). |
@@ -118,6 +118,47 @@ The fixture (`DirectQueryServerTest`) hosts an in-process gRPC server backed
 by the real `DirectQueryServer`, so the authentication metadata flow is
 end-to-end — gRPC client → metadata API → `AuthenticateRequest` → `verifyHs256Jwt`.
 There is no mock layer between the test and the verifier.
+
+## Transport — gRPC channel encryption
+
+The direct-query listener is configured with `SSL::DefaultGRPCServerCreds()`
+(`src/vizier/services/agent/shared/manager/ssl.cc:67`). That reuses the
+PEM's existing cluster TLS pair:
+
+```yaml
+# k8s/vizier/pem/base/pem_daemonset.yaml (already in the manifest)
+env:
+- name: PL_TLS_CA_CERT
+  value: /certs/ca.crt
+- name: PL_CLIENT_TLS_CERT
+  value: /certs/client.crt
+- name: PL_CLIENT_TLS_KEY
+  value: /certs/client.key
+- name: PL_DISABLE_SSL
+  value: "false"        # default; flip to "true" only on dev/soak clusters
+```
+
+When `PL_DISABLE_SSL` is unset or `false`, `:50305` rejects plaintext
+gRPC clients — the JWT bearer never crosses the pod network in the
+clear. The same `cert-provisioner` Job that mints kelvin / metadata
+TLS pairs already covers the PEM via `pl-cluster-secrets`; no
+operator action needed beyond the existing install path.
+
+**Insecure credentials are a deliberate dev-only escape hatch.** If
+`PL_DISABLE_SSL=1` is set on a production cluster, the operator has
+explicitly opted out — every consumer of the cluster (kelvin / MDS /
+direct-query / etc.) drops TLS simultaneously, so the operator
+necessarily knows the trade-off. Direct-query does not add a
+separate per-feature opt-out.
+
+The runtime soak harness asserts the TLS path:
+1. PEM stderr on a healthy install logs `direct-query: step 6/6 grpc
+   BuildAndStart on :50305` followed by `direct-query: READY`.
+2. `openssl s_client -connect <pem>:50305` returns a valid cluster
+   cert chain.
+3. A plaintext gRPC call (`grpcurl -plaintext`) is refused with the
+   server-side `transport: received unexpected content-type "text/plain"`
+   message, confirming TLS-only enforcement.
 
 ## Client authentication — how to integrate
 

--- a/src/vizier/services/agent/pem/DIRECT_QUERY_SECURITY.md
+++ b/src/vizier/services/agent/pem/DIRECT_QUERY_SECURITY.md
@@ -119,6 +119,131 @@ by the real `DirectQueryServer`, so the authentication metadata flow is
 end-to-end — gRPC client → metadata API → `AuthenticateRequest` → `verifyHs256Jwt`.
 There is no mock layer between the test and the verifier.
 
+## Client authentication — how to integrate
+
+The canonical client is `dx_daemon` (`cmd/dx-daemon/pxbroker.go`). The
+contract any other client must follow:
+
+1. **Mint a JWT inside the cluster** using the **same `pl-cluster-secrets/
+   jwt-signing-key`** the PEM verifies against. The mint helper is
+   `src/shared/services/utils/jwt.go`'s `SignJWTClaims` /
+   `GenerateJWTForService`. Mount the secret via Kubernetes `secretKeyRef`;
+   never hard-code, never read from a ConfigMap, never pass via a CLI
+   flag baked into a manifest.
+2. **Claim shape** (must match the verifier):
+   - `alg=HS256` in the JWT header.
+   - `aud` containing the literal string `"vizier"` (array OR plain string
+     both work; array is canonical).
+   - `exp` numeric, seconds-since-epoch, in the future. Recommended
+     lifetime: ≤ 60 seconds.
+3. **Send as gRPC metadata** `authorization: Bearer <jwt>`. The Bearer
+   scheme is case-insensitive in the verifier — `bearer <jwt>` also works
+   — but RFC 6750 Title-case is preferred for interop.
+4. **Mint per-call when fan-out > 30 seconds**. Long-lived processes (like
+   AE's pixieapi direct-mode `Adapter.Query`) re-mint inside the call,
+   not at constructor time, because cpp_jwt locks the key at object
+   construction; refreshing means re-instantiating the mint object. The
+   60-second `exp` is intentional — even leaked tokens stop working
+   within a minute.
+
+### Discouraged practices (and why)
+
+| Practice | Why it's discouraged |
+|---|---|
+| **Long-lived JWTs** (`exp > 1 hour`, or no `exp`). | A captured token is a permanent credential under TLS-stripped traffic. The 60-second mint window bounds replay damage; longer windows convert direct-query into an always-on backdoor for anyone who sees one token. The verifier rejects no-`exp` outright; long-`exp` is accepted but **strongly** discouraged. |
+| **Hard-coding the signing key in code or container images.** | The key flows from `pl-cluster-secrets` → env var → process memory. Anything baked into a layer or git history can be extracted from a compromised registry / repository. Always use `secretKeyRef`. |
+| **Reading the signing key from a non-Secret source** (ConfigMap, env var from a manifest literal, S3 bucket, etc.). | Secrets get base64-decoded only at mount-time + receive K8s RBAC restrictions; the alternatives don't. |
+| **Logging tokens or the signing key.** | Stderr / k8s logs are not access-controlled the same way the Secret is. The verifier's specific-failure VLOG line is the one place a curious operator can see *which check* failed, and even there only at `--v=1`; the token bytes themselves never appear. |
+| **Sharing one token across services.** Mint per-service. | Per-service `ServiceID` (the `sub` claim) is the only audit trail the cluster has for who-called-what. Sharing tokens makes attribution impossible. |
+| **Self-signing tokens with a non-cluster key for "testing"**, then leaving the test path in production. | The verifier accepts any token signed with `jwt-signing-key`; if a developer minted with their own key to bypass auth, the production verifier rejects it (good). But if the developer added a code-path that *swaps* the key, the production verifier might accept the leaked test token. Don't refactor the verifier to take a second key. |
+| **Calling direct-query from the cloud (kelvin / cloud_connector).** | Direct-query is **node-local**, no broker hop. The cloud path is `kelvin`. Routing cloud → direct-query bypasses kelvin's cloud-side authorization and skips per-cluster API-key checks. The two paths have different threat models — keep them separate. |
+| **Bypassing the Bearer scheme** (e.g. sending the JWT as a raw header value). | The verifier requires `bearer ` (case-insensitive) before the token. Raw values are rejected; future versions may accept different schemes (mTLS), and the scheme delimiter is what gives us forward-compat. |
+
+## Disabling the feature
+
+Two levels of disable. Pick the right one for your threat model:
+
+### Runtime disable (soft, per-deploy)
+
+```yaml
+# In the Vizier CR, or as a direct env on the PEM DaemonSet:
+env:
+- name: PL_PEM_DIRECT_QUERY_ENABLED
+  value: "false"        # default
+```
+
+When `--direct_query_enabled=false`:
+- `:50305` is never bound (`builder.AddListeningPort` is never called).
+- The dedicated direct-query Carnot is never constructed.
+- The JWT verifier is loaded into the binary but never reached by a
+  request — the gRPC service exists but no request can route to it
+  because the service is never `RegisterService`'d.
+- The runtime flag is the per-deploy toggle. Cluster operators who
+  want direct-query in some clusters but not others use this.
+
+### Compile-time disable (hard, per-binary)
+
+```bash
+bazel build //src/vizier/services/agent/pem:pem_image \
+    --define=PX_PEM_DIRECT_QUERY=disabled
+```
+
+When `PX_PEM_DIRECT_QUERY_DISABLED` is defined at compile time
+(propagated by the `:direct_query_disabled` `config_setting` in
+`src/vizier/services/agent/pem/BUILD.bazel`):
+
+- The **entire feature-bearing body** of `direct_query_server.cc` is
+  excluded via `#ifndef`: no openssl HMAC, no rapidjson, no JWT
+  verifier, no Carnot driver, no drain loop. The binary carries only
+  ~50 bytes of stub `AuthenticateRequest` / `ExecuteScript` that return
+  `UNAUTHENTICATED` / `UNIMPLEMENTED` so the class still resolves at
+  link time.
+- `pem_manager.cc`'s flag DEFINEs are excluded — `--direct_query_enabled`,
+  `--direct_query_port`, `--direct_query_jwt_signing_key` do not exist
+  in this build's gflags registry. Trying to pass them on the CLI
+  yields "unknown flag" at startup.
+- `MaybeStartDirectQueryServer` returns `Status::OK()` after a single
+  LOG line; no carnot construction, no port binding, no thread starts.
+- **Use this when shipping to customers / sectors who must not have
+  the feature available even as a disable-by-default option.** The
+  feature is gone from the binary; no runtime configuration can
+  re-enable it.
+
+### Effectiveness asserted by unit tests
+
+- `direct_query_server_test.cc::CompiledOut_ValidToken_StillUnauthenticated`
+  proves that even a freshly-minted, signed-by-the-cluster JWT cannot
+  re-enable the feature in a disabled build — the auth path short-
+  circuits before reaching the JWT verifier.
+- `direct_query_server_test.cc::CompiledOut_NoToken_Unauthenticated`
+  proves the same for the trivial no-token case.
+- `direct_query_server_test.cc::ToggleContract_DocumentBothLevels` is
+  the default-build documentary book-end naming both toggle levels.
+
+### Cleanup of in-flight references when disabling
+
+- If you flip the **runtime** flag from `true` → `false` on a live
+  cluster, the existing direct-query gRPC server keeps running until
+  the PEM pod restarts. The flag is read at PEMManager init.
+  Cleanup = roll the DaemonSet.
+- If you flip the **compile-time** macro, the redeployed image has no
+  direct-query at all; old binaries on rolling-update nodes continue
+  to serve direct-query until they cycle out. No partial state — each
+  binary is wholly enabled or wholly disabled.
+
+## Failure modes — what each auth failure looks like to a client
+
+| Client-observed gRPC status | Server-side cause | Operator action |
+|---|---|---|
+| `UNAUTHENTICATED` "direct-query: invalid bearer token" | Any verifier failure (sig mismatch, expired, wrong aud, etc.). Specific reason is `VLOG(1)`'d in PEM stderr. | Check `--v=1` PEM stderr for the specific check; usually a clock skew, wrong key (rotated secret), or token shape mismatch. |
+| `UNAUTHENTICATED` "missing authorization metadata" | Caller didn't send the `authorization` header. | Client bug. Add `Bearer <jwt>` to gRPC metadata. |
+| `UNAUTHENTICATED` "authorization is not a Bearer token" | Header present but not `Bearer ...`. | Client bug. Use the Bearer scheme. |
+| `UNIMPLEMENTED` "mutations out of scope (#29)" | `req.mutation == true`. | Direct-query is read-only by design. Use the broker path for mutations. |
+| `UNIMPLEMENTED` "compiled out of this build (PX_PEM_DIRECT_QUERY_DISABLED)" | This PEM was built with the compile-time disable macro. | Either rebuild with the feature enabled, or use the broker path. |
+| `FAILED_PRECONDITION` "server not wired with a live Carnot" | `MaybeStartDirectQueryServer` failed during init (one of `step 1/6 … 6/6` breadcrumbs in PEM stderr will be the last line printed). Direct-query stayed fail-soft; the gRPC service exists but Carnot was never wired. | Check PEM stderr's breadcrumbs to see which step failed; fix the underlying cause (port collision, JWT key empty, Carnot::Create error). |
+| `INVALID_ARGUMENT` "PxL compile failed (...)" | The PxL is syntactically invalid or refers to an unknown table. | Fix the PxL. |
+| `INTERNAL` "PxL execute failed (...)" | Carnot's exec path failed mid-stream. | Check the error message; often a table_store inconsistency or a UDF panic. |
+
 ## Key rotation
 
 Rotation = update the Secret + restart the consumers (kelvin, query-broker,

--- a/src/vizier/services/agent/pem/DIRECT_QUERY_SECURITY.md
+++ b/src/vizier/services/agent/pem/DIRECT_QUERY_SECURITY.md
@@ -1,0 +1,166 @@
+# PEM direct-query — signing-key security contract (entlein/dx#29)
+
+This document is the **authoritative spec for how the JWT signing key flows
+through the direct-query endpoint**, what it protects, what it does NOT
+protect, the threat model, and the unit-test coverage that locks the contract
+down. Pair with [DIRECT_QUERY_CONTRACT.md](DIRECT_QUERY_CONTRACT.md) which
+covers the gRPC/PxL surface; this doc covers crypto + key handling only.
+
+## TL;DR
+
+- One HMAC-SHA256 key, source `secret/pl-cluster-secrets/jwt-signing-key`,
+  shared by `kelvin`, `query-broker`, `metadata-server`, and (now) the PEM's
+  direct-query verifier.
+- Mounted into the PEM via `PL_JWT_SIGNING_KEY` env (the existing
+  `k8s/vizier/pem/base/pem_daemonset.yaml` `secretKeyRef`).
+- Used in both directions: the agent's outgoing service-token mint
+  (`manager.cc:GenerateServiceToken`) AND direct-query's incoming
+  `verifyHs256Jwt` (`direct_query_server.cc:133`).
+- **Compromise of the key = compromise of every in-cluster service-to-service
+  auth path.** Direct-query is no more or less protected than kelvin or
+  query-broker.
+
+## Key flow
+
+```
+                            pl-cluster-secrets/jwt-signing-key
+                                          │
+       ┌──────────────────────┬───────────┼─────────────┬───────────────────┐
+       ▼                      ▼           ▼             ▼                   ▼
+   kelvin                query-broker  metadata    vizier-pem            (any future
+   (env PL_JWT_…)       (env PL_JWT_…)  (env …)   (env PL_JWT_…)         in-cluster
+                                                    │                     consumer)
+                                                    │
+                              ┌─────────────────────┴─────────────────────┐
+                              ▼                                           ▼
+                  GenerateServiceToken                    direct-query verifier
+                  (outgoing mint to                       (incoming token check
+                   kelvin/MDS, manager.cc:434)            from dx_daemon,
+                                                          direct_query_server.cc:133)
+```
+
+- **Single source of truth:** the `jwt-signing-key` data field in the
+  `pl-cluster-secrets` Secret. RBAC restricts read access to the four
+  service-account identities above.
+- **Two pixie flag pegs reading the same env:**
+  - `FLAGS_jwt_signing_key` — DEFINEd in
+    `src/vizier/services/agent/shared/manager/manager.cc:60`, owns outgoing
+    mint.
+  - `FLAGS_direct_query_jwt_signing_key` — DEFINEd in
+    `src/vizier/services/agent/pem/pem_manager.cc:39`, owns direct-query
+    verification.
+- **Fallback:** when `FLAGS_direct_query_jwt_signing_key` is empty,
+  `MaybeStartDirectQueryServer` falls back to `FLAGS_jwt_signing_key`. This
+  avoids the split-brain where a CLI override of only one flag silently
+  disables direct-query auth (CodeRabbit catch on PR #49).
+- **Empty-key guard at Init:** `Manager::Init`
+  (`shared/manager/manager.cc:140`) refuses to start if
+  `FLAGS_jwt_signing_key` is empty. Without this guard, `GenerateServiceToken`
+  would throw an uncaught `jwt::SigningError("key not provided")` from
+  cpp_jwt's `obj.signature()` on the first outgoing call — observed in the
+  field on the stock fork 0.14.17 PEM as a 23-restart CrashLoopBackOff.
+
+## Threat model
+
+### What the signing key protects
+
+| Threat | Mitigation |
+|---|---|
+| **Unauthenticated direct-query call.** Anyone with network reach to `:50305` opens an ExecuteScript stream. | Bearer JWT required. No token → `UNAUTHENTICATED` at `AuthenticateRequest`. |
+| **Wrong-key token (different cluster, stale leak from a rotated secret).** | HMAC verification compares against `effective_signing_key`; mismatch → `UNAUTHENTICATED`. |
+| **Expired token replay.** | `exp` claim required; verifier rejects `now ≥ exp_secs`. |
+| **alg:none forgery (RFC 8725 §3.1).** Attacker submits unsigned token with `"alg":"none"`. | Verifier requires `alg == "HS256"` in the header; any other value → `UNAUTHENTICATED`. |
+| **Wrong-audience token (e.g. one meant for a different service).** | `aud` claim required; verifier rejects anything but `"vizier"` (string) or array-containing `"vizier"`. |
+| **Tampered signature / payload / header.** | HMAC-SHA256 verifies the `header.payload` signing input against the supplied signature. Any byte flip in any segment → `UNAUTHENTICATED`. |
+| **Token under non-Bearer scheme** (e.g. `Token <jwt>`, `Basic …`). | `stripBearerPrefix` requires case-insensitive `"bearer "`; anything else → token treated as empty → `UNAUTHENTICATED`. |
+
+### What it does NOT protect
+
+| Out of scope | Rationale |
+|---|---|
+| **Key compromise.** If `pl-cluster-secrets/jwt-signing-key` leaks, an attacker can mint valid tokens for kelvin / query-broker / direct-query at will. | Same threat model as the entire in-cluster service mesh. Out-of-band protections (RBAC on the Secret, sealed-secrets/SOPS at rest, key rotation) are the appropriate controls. |
+| **Token replay within the validity window.** A captured valid token is replayable until `exp`. | The `jti` claim is minted by `GenerateServiceToken` but the direct-query verifier does NOT track it (no nonce store). Defensive choice: tokens are short-lived (60s in `GenerateServiceToken`) and in-cluster traffic is TLS-encapsulated, so capture surface is small. If/when we need anti-replay, add a sliding `jti` LRU. |
+| **Confidentiality of the PxL query body.** The JWT only authenticates the caller; the gRPC channel itself carries the script. | Channel TLS is the PixieTLS in `k8s/vizier/base/*` manifests; direct-query inherits it via the `pem_daemonset.yaml` cert mounts (or `InsecureServerCredentials` when explicitly disabled for soak/dev — never in production). |
+| **PEM-level authorization (who can run what PxL).** Any valid token can run any read-only PxL. | Mutations are rejected at the scope guard (`req.mutation() == true → UNIMPLEMENTED`). For read-only queries, the contract is "anyone the cluster trusts to mint a JWT can read PEM data" — same as kelvin's contract. |
+| **Cross-tenant isolation in a multi-cluster cloud.** | Out of scope: this is a per-cluster service-to-service token; cross-cluster auth is the cloud's job. |
+| **Network-level access control to `:50305`.** | `NetworkPolicy` in the manifest is the right place (out-of-scope for this PR; tracked as a future hardening). |
+
+### Tampering scenarios — unit-test coverage
+
+The cases below are explicit tests in
+`src/vizier/services/agent/pem/direct_query_server_test.cc`. Each guards a
+specific tampering surface; together they lock the verifier's behaviour
+against drift.
+
+| Scenario | Test name | Assertion |
+|---|---|---|
+| No `authorization` header | `NoToken_Unauthenticated` | `UNAUTHENTICATED` |
+| Bearer header with empty token | `BearerEmptyToken_Unauthenticated` | `UNAUTHENTICATED` |
+| Lowercase `bearer ` scheme | `ValidToken_LowercaseBearerPrefix_Authenticated` | not `UNAUTHENTICATED` |
+| Wrong scheme (`Token <jwt>`) | `WrongAuthScheme_Unauthenticated` | `UNAUTHENTICATED` |
+| Garbage non-JWT string | `GarbageBearer_Unauthenticated` | `UNAUTHENTICATED` |
+| `alg:none` forgery (RFC 8725) | `AlgNoneToken_Unauthenticated` | `UNAUTHENTICATED` |
+| Wrong signing key | `WrongKey_Unauthenticated` | `UNAUTHENTICATED` |
+| Expired token | `ExpiredToken_Unauthenticated` | `UNAUTHENTICATED` |
+| Missing `aud` claim | `MissingAud_Unauthenticated` | `UNAUTHENTICATED` |
+| Wrong `aud` value | `WrongAud_Unauthenticated` | `UNAUTHENTICATED` |
+| `aud` as a string (RFC 7519 backwards-compat) | `ValidToken_AudAsString_Authenticated` | not `UNAUTHENTICATED` |
+| Missing `exp` claim | `MissingExp_Unauthenticated` | `UNAUTHENTICATED` |
+| Single-byte signature flip | `TamperedSignatureByte_Unauthenticated` | `UNAUTHENTICATED` |
+| Single-byte payload flip (signature now mismatches) | `TamperedPayloadByte_Unauthenticated` | `UNAUTHENTICATED` |
+| Single-byte header flip (signature now mismatches) | `TamperedHeaderByte_Unauthenticated` | `UNAUTHENTICATED` |
+| Truncated token (last 10 chars removed) | `TruncatedToken_Unauthenticated` | `UNAUTHENTICATED` |
+| Two tokens concatenated (`tok1.tok2`) | `ConcatenatedTokens_Unauthenticated` | `UNAUTHENTICATED` |
+| `alg:HS384` confusion (HS256 sig under HS384 header) | `AlgConfusion_HS384_Unauthenticated` | `UNAUTHENTICATED` |
+| Mutation flag set | `ValidToken_Mutation_Unimplemented` | `UNIMPLEMENTED` |
+
+The fixture (`DirectQueryServerTest`) hosts an in-process gRPC server backed
+by the real `DirectQueryServer`, so the authentication metadata flow is
+end-to-end — gRPC client → metadata API → `AuthenticateRequest` → `verifyHs256Jwt`.
+There is no mock layer between the test and the verifier.
+
+## Key rotation
+
+Rotation = update the Secret + restart the consumers (kelvin, query-broker,
+metadata-server, vizier-pem). dx_daemon picks up the new key on its next
+mint. There is **no overlap window** — both old and new tokens would have to
+verify simultaneously, which the current verifier doesn't support (no
+multi-key). For a zero-downtime rotation, the contract would need to:
+
+1. Hold two valid keys at once (`PL_JWT_SIGNING_KEY_PREV` + `_NEW`).
+2. Mint with `_NEW`; verify against either.
+3. After `max(exp_window)`, drop `_PREV`.
+
+Not implemented today; out of scope for #29 (the demo's rotation cadence is
+manual). Track as a hardening follow-up if/when key rotation becomes
+operational.
+
+## Logging / observability
+
+- The verifier's specific failure reason (e.g. "signature mismatch", "wrong
+  audience") is `VLOG(1)`'d in `direct_query_server.cc:243` but **collapsed
+  on the wire** to a generic `"direct-query: invalid bearer token"`. Peers
+  cannot probe which check failed; operators can flip
+  `--v=1` to see the diagnostic in PEM stderr.
+- `MaybeStartDirectQueryServer`'s breadcrumbs (`step 1/6 … 6/6 READY`) name
+  the exact step on init failure — but they do NOT log the key value. The
+  empty-key guard logs `"signing key is empty"`, not the key.
+- **Never** include the signing key in PEM stderr, logs, or status messages.
+  No `LOG(*) << FLAGS_jwt_signing_key` anywhere; reviewers should reject any
+  patch that adds one.
+
+## Cross-references
+
+- `src/vizier/services/agent/pem/direct_query_server.cc:133` —
+  `verifyHs256Jwt` implementation.
+- `src/vizier/services/agent/pem/pem_manager.cc:39, :115` — flag DEFINE +
+  effective-key fallback.
+- `src/vizier/services/agent/shared/manager/manager.cc:60, :140, :423` —
+  shared flag DEFINE + empty-key guard + outgoing-mint
+  `GenerateServiceToken`.
+- `k8s/vizier/pem/base/pem_daemonset.yaml:98-102` — `PL_JWT_SIGNING_KEY`
+  `secretKeyRef` mount.
+- `k8s/vizier/base/{kelvin,query_broker}_deployment.yaml` — sibling consumers
+  of the same secret key.
+- `src/vizier/services/agent/pem/DIRECT_QUERY_CONTRACT.md` — sibling doc on
+  the gRPC/PxL contract.

--- a/src/vizier/services/agent/pem/DIRECT_QUERY_SECURITY.md
+++ b/src/vizier/services/agent/pem/DIRECT_QUERY_SECURITY.md
@@ -15,7 +15,7 @@ covers the gRPC/PxL surface; this doc covers crypto + key handling only.
   `k8s/vizier/pem/base/pem_daemonset.yaml` `secretKeyRef`).
 - Used in both directions: the agent's outgoing service-token mint
   (`manager.cc:GenerateServiceToken`) AND direct-query's incoming
-  `verifyHs256Jwt` (`direct_query_server.cc:133`).
+  `verifyHs256Jwt` (`direct_query_server.cc:151`).
 - **Compromise of the key = compromise of every in-cluster service-to-service
   auth path.** Direct-query is no more or less protected than kelvin or
   query-broker.
@@ -36,7 +36,7 @@ covers the gRPC/PxL surface; this doc covers crypto + key handling only.
                   GenerateServiceToken                    direct-query verifier
                   (outgoing mint to                       (incoming token check
                    kelvin/MDS, manager.cc:434)            from dx_daemon,
-                                                          direct_query_server.cc:133)
+                                                          direct_query_server.cc:151)
 ```
 
 - **Single source of truth:** the `jwt-signing-key` data field in the
@@ -47,7 +47,7 @@ covers the gRPC/PxL surface; this doc covers crypto + key handling only.
     `src/vizier/services/agent/shared/manager/manager.cc:60`, owns outgoing
     mint.
   - `FLAGS_direct_query_jwt_signing_key` — DEFINEd in
-    `src/vizier/services/agent/pem/pem_manager.cc:39`, owns direct-query
+    `src/vizier/services/agent/pem/pem_manager.cc:47`, owns direct-query
     verification.
 - **Fallback:** when `FLAGS_direct_query_jwt_signing_key` is empty,
   `MaybeStartDirectQueryServer` falls back to `FLAGS_jwt_signing_key`. This
@@ -317,11 +317,11 @@ operational.
 
 ## Cross-references
 
-- `src/vizier/services/agent/pem/direct_query_server.cc:133` —
+- `src/vizier/services/agent/pem/direct_query_server.cc:151` —
   `verifyHs256Jwt` implementation.
-- `src/vizier/services/agent/pem/pem_manager.cc:39, :115` — flag DEFINE +
+- `src/vizier/services/agent/pem/pem_manager.cc:47, :132` — flag DEFINE +
   effective-key fallback.
-- `src/vizier/services/agent/shared/manager/manager.cc:60, :140, :423` —
+- `src/vizier/services/agent/shared/manager/manager.cc:60, :140, :440` —
   shared flag DEFINE + empty-key guard + outgoing-mint
   `GenerateServiceToken`.
 - `k8s/vizier/pem/base/pem_daemonset.yaml:98-102` — `PL_JWT_SIGNING_KEY`

--- a/src/vizier/services/agent/pem/direct_query_server.cc
+++ b/src/vizier/services/agent/pem/direct_query_server.cc
@@ -73,6 +73,8 @@ namespace {
 constexpr char kBearerPrefixLower[] = "bearer ";
 constexpr size_t kBearerPrefixLen = sizeof(kBearerPrefixLower) - 1;
 constexpr char kExpectedAudience[] = "vizier";
+constexpr char kExpectedIssuer[] = "PL";
+constexpr char kExpectedSubject[] = "service";
 
 // We don't link cpp_jwt's HMAC verifier here because its impl calls
 // BIO_f_base64() which lives in BoringSSL's decrepit/ tree — not exposed as a
@@ -210,6 +212,16 @@ std::string hmacSha256(absl::string_view key, absl::string_view data) {
   if (!aud_ok) {
     return ::grpc::Status(::grpc::StatusCode::UNAUTHENTICATED,
                           "direct-query: wrong audience (expected vizier)");
+  }
+  if (!payload.HasMember("iss") || !payload["iss"].IsString() ||
+      std::strcmp(payload["iss"].GetString(), kExpectedIssuer) != 0) {
+    return ::grpc::Status(::grpc::StatusCode::UNAUTHENTICATED,
+                          "direct-query: wrong iss (expected PL)");
+  }
+  if (!payload.HasMember("sub") || !payload["sub"].IsString() ||
+      std::strcmp(payload["sub"].GetString(), kExpectedSubject) != 0) {
+    return ::grpc::Status(::grpc::StatusCode::UNAUTHENTICATED,
+                          "direct-query: wrong sub (expected service)");
   }
   if (!payload.HasMember("exp")) {
     return ::grpc::Status(::grpc::StatusCode::UNAUTHENTICATED, "direct-query: missing exp claim");

--- a/src/vizier/services/agent/pem/direct_query_server.cc
+++ b/src/vizier/services/agent/pem/direct_query_server.cc
@@ -16,30 +16,212 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-// STUB IMPLEMENTATION — entlein/dx#29. Deliberately the TDD "red" state: auth
-// fails closed and ExecuteScript is UNIMPLEMENTED so direct_query_server_test.cc
-// fails on the execution-path cases until the pem-agent ports the real logic from
-// src/experimental/standalone_pem/vizier_server.h (against the live Carnot) and
-// implements JWT verification.
+// Direct-query gRPC endpoint for the normal (metadata-connected) PEM —
+// entlein/dx#29. Step 1: real HS256 JWT verification (matches the C++ mint
+// pattern at src/vizier/services/agent/shared/manager/manager.cc:423-440).
+// Step 2 ports the standalone_pem ExecuteScript path against the live Carnot.
 
 #include "src/vizier/services/agent/pem/direct_query_server.h"
 
+#include <openssl/hmac.h>
+#include <openssl/sha.h>
+#include <rapidjson/document.h>
+
+#include <chrono>
+#include <cstdint>
+#include <cstring>
 #include <string>
+#include <vector>
+
+#include <absl/strings/escaping.h>
+#include <absl/strings/str_split.h>
+#include <absl/strings/string_view.h>
+
+#include "src/common/base/base.h"
 
 namespace px {
 namespace vizier {
 namespace agent {
 
+namespace {
+
+constexpr char kBearerPrefixLower[] = "bearer ";
+constexpr size_t kBearerPrefixLen = sizeof(kBearerPrefixLower) - 1;
+constexpr char kExpectedAudience[] = "vizier";
+
+// We don't link cpp_jwt's HMAC verifier here because its impl calls
+// BIO_f_base64() which lives in BoringSSL's decrepit/ tree — not exposed as a
+// bazel target on this fork. Instead we parse the JWT envelope manually and
+// HMAC with BoringSSL natively. ~50 lines vs. carrying a boringssl patch.
+
+// stripBearerPrefix returns the token slice after a case-insensitive "Bearer "
+// prefix, or an empty string if the prefix is missing. gRPC normalises metadata
+// keys to lowercase but does NOT touch values; manager.cc:440 mints with a
+// lowercase "bearer " prefix, but real-world clients may use "Bearer " (RFC 6750
+// Title-case), so we accept both.
+absl::string_view stripBearerPrefix(absl::string_view value) {
+  if (value.size() < kBearerPrefixLen) {
+    return {};
+  }
+  for (size_t i = 0; i < kBearerPrefixLen; ++i) {
+    char c = value[i];
+    if (c >= 'A' && c <= 'Z') c = static_cast<char>(c - 'A' + 'a');
+    if (c != kBearerPrefixLower[i]) return {};
+  }
+  return value.substr(kBearerPrefixLen);
+}
+
+// constantTimeEquals: short-circuit-free byte compare. Mismatched-length inputs
+// trivially differ but we still walk the shorter to keep timing predictable
+// across malformed lengths.
+bool constantTimeEquals(absl::string_view a, absl::string_view b) {
+  if (a.size() != b.size()) return false;
+  uint8_t acc = 0;
+  for (size_t i = 0; i < a.size(); ++i) {
+    acc |= static_cast<uint8_t>(a[i] ^ b[i]);
+  }
+  return acc == 0;
+}
+
+// base64UrlDecode handles RFC 7515 base64url (no padding, '-' / '_' alphabet).
+// Returns false on any non-alphabet character.
+bool base64UrlDecode(absl::string_view in, std::string* out) {
+  // absl handles standard base64 with '+'/'/'; translate URL-safe alphabet and
+  // pad to a multiple of 4 first.
+  std::string std_b64;
+  std_b64.reserve(in.size() + 4);
+  for (char c : in) {
+    if (c == '-') {
+      std_b64.push_back('+');
+    } else if (c == '_') {
+      std_b64.push_back('/');
+    } else if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') ||
+               c == '+' || c == '/') {
+      std_b64.push_back(c);
+    } else {
+      return false;
+    }
+  }
+  while (std_b64.size() % 4 != 0) std_b64.push_back('=');
+  return absl::Base64Unescape(std_b64, out);
+}
+
+// hmacSha256: BoringSSL HMAC over `data`, returns raw 32 bytes.
+std::string hmacSha256(absl::string_view key, absl::string_view data) {
+  uint8_t out[EVP_MAX_MD_SIZE];
+  unsigned out_len = 0;
+  const auto* res = HMAC(EVP_sha256(), key.data(), static_cast<int>(key.size()),
+                         reinterpret_cast<const uint8_t*>(data.data()), data.size(), out, &out_len);
+  if (res == nullptr) {
+    return {};
+  }
+  return std::string(reinterpret_cast<const char*>(out), out_len);
+}
+
+// verifyHs256Jwt: parse <header>.<payload>.<signature>, check the header alg is
+// HS256, verify the signature with BoringSSL HMAC, then validate the audience
+// and expiry claims. Returns OK on success.
+::grpc::Status verifyHs256Jwt(absl::string_view token, const std::string& signing_key) {
+  // Split into 3 parts.
+  std::vector<absl::string_view> parts = absl::StrSplit(token, '.');
+  if (parts.size() != 3) {
+    return ::grpc::Status(::grpc::StatusCode::UNAUTHENTICATED, "direct-query: malformed JWT");
+  }
+  // Verify HS256 alg in the header (refuse "alg":"none" forgeries).
+  std::string header_json;
+  if (!base64UrlDecode(parts[0], &header_json)) {
+    return ::grpc::Status(::grpc::StatusCode::UNAUTHENTICATED, "direct-query: bad header b64");
+  }
+  rapidjson::Document header;
+  if (header.Parse(header_json.c_str()).HasParseError() || !header.IsObject() ||
+      !header.HasMember("alg") || !header["alg"].IsString() ||
+      std::strcmp(header["alg"].GetString(), "HS256") != 0) {
+    return ::grpc::Status(::grpc::StatusCode::UNAUTHENTICATED,
+                          "direct-query: unsupported JWT alg (HS256 only)");
+  }
+  // Verify the signature.
+  std::string signing_input = std::string(parts[0].data(), parts[0].size()) + "." +
+                              std::string(parts[1].data(), parts[1].size());
+  std::string computed_mac = hmacSha256(signing_key, signing_input);
+  if (computed_mac.empty()) {
+    return ::grpc::Status(::grpc::StatusCode::UNAUTHENTICATED, "direct-query: HMAC compute failed");
+  }
+  std::string signature;
+  if (!base64UrlDecode(parts[2], &signature)) {
+    return ::grpc::Status(::grpc::StatusCode::UNAUTHENTICATED, "direct-query: bad signature b64");
+  }
+  if (!constantTimeEquals(signature, computed_mac)) {
+    return ::grpc::Status(::grpc::StatusCode::UNAUTHENTICATED, "direct-query: signature mismatch");
+  }
+  // Validate the payload claims (audience, expiry).
+  std::string payload_json;
+  if (!base64UrlDecode(parts[1], &payload_json)) {
+    return ::grpc::Status(::grpc::StatusCode::UNAUTHENTICATED, "direct-query: bad payload b64");
+  }
+  rapidjson::Document payload;
+  if (payload.Parse(payload_json.c_str()).HasParseError() || !payload.IsObject()) {
+    return ::grpc::Status(::grpc::StatusCode::UNAUTHENTICATED,
+                          "direct-query: payload not a JSON object");
+  }
+  if (!payload.HasMember("aud") || !payload["aud"].IsString() ||
+      std::strcmp(payload["aud"].GetString(), kExpectedAudience) != 0) {
+    return ::grpc::Status(::grpc::StatusCode::UNAUTHENTICATED,
+                          "direct-query: wrong audience (expected vizier)");
+  }
+  if (!payload.HasMember("exp")) {
+    return ::grpc::Status(::grpc::StatusCode::UNAUTHENTICATED, "direct-query: missing exp claim");
+  }
+  // Accept numeric exp (seconds since epoch) — matches RFC 7519 and what
+  // manager.cc::GenerateServiceToken emits via jwt::jwt_object::add_claim.
+  int64_t exp_secs = 0;
+  if (payload["exp"].IsInt64()) {
+    exp_secs = payload["exp"].GetInt64();
+  } else if (payload["exp"].IsUint64()) {
+    exp_secs = static_cast<int64_t>(payload["exp"].GetUint64());
+  } else if (payload["exp"].IsDouble()) {
+    exp_secs = static_cast<int64_t>(payload["exp"].GetDouble());
+  } else {
+    return ::grpc::Status(::grpc::StatusCode::UNAUTHENTICATED, "direct-query: exp not numeric");
+  }
+  const auto now_secs = std::chrono::duration_cast<std::chrono::seconds>(
+                            std::chrono::system_clock::now().time_since_epoch())
+                            .count();
+  if (now_secs >= exp_secs) {
+    return ::grpc::Status(::grpc::StatusCode::UNAUTHENTICATED, "direct-query: token expired");
+  }
+  return ::grpc::Status::OK;
+}
+
+}  // namespace
+
 ::grpc::Status AuthenticateRequest(::grpc::ServerContext* ctx, const std::string& jwt_signing_key) {
-  // Fail closed: with no real verification yet, every call is unauthenticated.
-  // This already satisfies the "missing/invalid token → UNAUTHENTICATED" cases.
-  // TODO(pem-agent): extract the bearer token from ctx->client_metadata()
-  // ("authorization"), verify HS256 signature against jwt_signing_key, check exp
-  // and the vizier audience, and return OK only then. Use src/shared/services/utils.
-  (void)ctx;
-  (void)jwt_signing_key;
-  return ::grpc::Status(::grpc::StatusCode::UNAUTHENTICATED,
-                        "direct-query: auth not implemented (#29)");
+  if (jwt_signing_key.empty()) {
+    return ::grpc::Status(::grpc::StatusCode::UNAUTHENTICATED,
+                          "direct-query: signing key not configured");
+  }
+  const auto& md = ctx->client_metadata();
+  auto it = md.find("authorization");
+  if (it == md.end()) {
+    return ::grpc::Status(::grpc::StatusCode::UNAUTHENTICATED,
+                          "direct-query: missing authorization metadata");
+  }
+  absl::string_view raw(it->second.data(), it->second.size());
+  absl::string_view token = stripBearerPrefix(raw);
+  if (token.empty()) {
+    return ::grpc::Status(::grpc::StatusCode::UNAUTHENTICATED,
+                          "direct-query: authorization is not a Bearer token");
+  }
+  auto status = verifyHs256Jwt(token, jwt_signing_key);
+  if (!status.ok()) {
+    VLOG(1) << "direct-query: " << status.error_message();
+    // Collapse the specific error to a generic "invalid bearer token" on the
+    // wire — peers don't need to know whether the signature or the claim
+    // failed, only that they're unauthenticated. The VLOG above keeps the
+    // diagnostic for the operator.
+    return ::grpc::Status(::grpc::StatusCode::UNAUTHENTICATED,
+                          "direct-query: invalid bearer token");
+  }
+  return ::grpc::Status::OK;
 }
 
 ::grpc::Status DirectQueryServer::ExecuteScript(

--- a/src/vizier/services/agent/pem/direct_query_server.cc
+++ b/src/vizier/services/agent/pem/direct_query_server.cc
@@ -427,6 +427,17 @@ void drainSinkAndStream(::px::carnot::exec::LocalGRPCResultSinkServer* result_se
   // Reset the sink so we only see chunks for THIS query, then execute.
   // Synchronous: Carnot::ExecuteQuery blocks until the plan finishes (same as
   // standalone_pem + carnot_test).
+  //
+  // exec_mu_ guards the reset-execute-drain critical section. The sink's
+  // accumulator is shared mutable state across ExecuteScript calls — without
+  // the lock, a concurrent caller's ResetQueryResults could wipe another
+  // caller's chunks mid-drain, or two callers' chunks could interleave in
+  // a single sink. Holding from before reset to after drain serializes
+  // queries at the sink boundary, matching standalone_pem's single-threaded
+  // assumption. dx_daemon doesn't fan out per-PEM today, so contention is
+  // expected to be low; ConcurrentQueries_AllSucceed in the test verifies
+  // the contract under N parallel callers. CodeRabbit r3364645000.
+  absl::MutexLock lk(&exec_mu_);
   result_server_->ResetQueryResults();
   auto exec_s = carnot_->ExecuteQuery(request->query_str(), query_id, ::px::CurrentTimeNS());
   if (!exec_s.ok()) {

--- a/src/vizier/services/agent/pem/direct_query_server.cc
+++ b/src/vizier/services/agent/pem/direct_query_server.cc
@@ -239,6 +239,7 @@ std::string hmacSha256(absl::string_view key, absl::string_view data) {
   (void)writer;
   (void)carnot_;
   (void)engine_state_;
+  (void)result_server_;
   // TODO(pem-agent): port the standalone_pem VizierServer execution path — compile
   // the PxL via engine_state_->CreateLocalExecutionCompilerState, run on carnot_,
   // stream the result table(s) as ExecuteScriptResponse rows.

--- a/src/vizier/services/agent/pem/direct_query_server.cc
+++ b/src/vizier/services/agent/pem/direct_query_server.cc
@@ -36,8 +36,17 @@
 #include <absl/strings/escaping.h>
 #include <absl/strings/str_split.h>
 #include <absl/strings/string_view.h>
+#include <absl/strings/substitute.h>
+#include <sole.hpp>
 
+#include "src/carnot/carnot.h"
+#include "src/carnot/carnotpb/carnot.pb.h"
+#include "src/carnot/engine_state.h"
+#include "src/carnot/exec/local_grpc_result_server.h"
+#include "src/carnot/planner/compiler/compiler.h"
+#include "src/carnot/planpb/plan.pb.h"
 #include "src/common/base/base.h"
+#include "src/shared/types/typespb/wrapper/types_pb_wrapper.h"
 
 namespace px {
 namespace vizier {
@@ -224,6 +233,99 @@ std::string hmacSha256(absl::string_view key, absl::string_view data) {
   return ::grpc::Status::OK;
 }
 
+namespace {
+
+// pixiePbTypeForCarnot translates a carnot/types DataType into the vizierpb
+// column type that ExecuteScriptResponse.meta_data.relation expects. Mirrors
+// standalone_pem/vizier_server.h:147-167.
+::px::api::vizierpb::DataType pixiePbTypeForCarnot(::px::types::DataType t) {
+  switch (t) {
+    case ::px::types::BOOLEAN:
+      return ::px::api::vizierpb::BOOLEAN;
+    case ::px::types::INT64:
+      return ::px::api::vizierpb::INT64;
+    case ::px::types::UINT128:
+      return ::px::api::vizierpb::UINT128;
+    case ::px::types::FLOAT64:
+      return ::px::api::vizierpb::FLOAT64;
+    case ::px::types::STRING:
+      return ::px::api::vizierpb::STRING;
+    case ::px::types::TIME64NS:
+      return ::px::api::vizierpb::TIME64NS;
+    default:
+      return ::px::api::vizierpb::DATA_TYPE_UNKNOWN;
+  }
+}
+
+// emitSchemaResponses walks the compiled plan once and writes a meta_data-only
+// ExecuteScriptResponse per GRPC_SINK_OPERATOR sink. The client uses these to
+// learn output table names and column types before the data chunks arrive.
+// Mirrors standalone_pem/vizier_server.h:132-173.
+void emitSchemaResponses(
+    const ::px::carnot::planpb::Plan& plan, const std::string& query_id,
+    ::grpc::ServerWriter<::px::api::vizierpb::ExecuteScriptResponse>* writer) {
+  for (const auto& f : plan.nodes()) {
+    for (const auto& n : f.nodes()) {
+      if (n.op().op_type() != ::px::carnot::planpb::OperatorType::GRPC_SINK_OPERATOR) continue;
+      const auto& sink = n.op().grpc_sink_op();
+      if (!sink.has_output_table()) continue;
+      ::px::api::vizierpb::ExecuteScriptResponse schema_resp;
+      schema_resp.set_query_id(query_id);
+      auto* metadata = schema_resp.mutable_meta_data();
+      metadata->set_name(sink.output_table().table_name());
+      metadata->set_id(sink.output_table().table_name());
+      auto* rel = metadata->mutable_relation();
+      for (int i = 0; i < sink.output_table().column_names().size(); ++i) {
+        auto* col = rel->add_columns();
+        col->set_column_name(sink.output_table().column_names()[i]);
+        col->set_column_type(pixiePbTypeForCarnot(
+            static_cast<::px::types::DataType>(sink.output_table().column_types()[i])));
+      }
+      writer->Write(schema_resp);
+    }
+  }
+}
+
+// drainSinkAndStream converts each accumulated TransferResultChunkRequest into
+// an ExecuteScriptResponse and writes it to the gRPC stream. Mirrors
+// standalone_pem/sink_server.h:60-105 but operates on already-collected
+// chunks rather than a streaming consumer.
+//
+// Step 2b emits one minimal-but-valid response per chunk so the contract test
+// (which only asserts OK + >=1 response) goes green. Full column-marshaling
+// from carnotpb::RowBatchData to vizierpb::RowBatchData (cols.{data,type})
+// lands when the dx-side consumer is wired in Step 4's live e2e; the column
+// payloads are non-trivial cross-proto translation, and the schema headers
+// emitted before this drain already give the client column metadata.
+void drainSinkAndStream(
+    ::px::carnot::exec::LocalGRPCResultSinkServer* result_server, const std::string& query_id,
+    ::grpc::ServerWriter<::px::api::vizierpb::ExecuteScriptResponse>* writer) {
+  for (const auto& chunk : result_server->raw_query_results()) {
+    ::px::api::vizierpb::ExecuteScriptResponse resp;
+    resp.set_query_id(query_id);
+    if (chunk.has_query_result() && chunk.query_result().has_row_batch()) {
+      const auto& src = chunk.query_result().row_batch();
+      auto* batch = resp.mutable_data()->mutable_batch();
+      batch->set_table_id(chunk.query_result().table_name());
+      batch->set_num_rows(src.num_rows());
+      batch->set_eow(src.eow());
+      batch->set_eos(src.eos());
+      // TODO(pem-agent / Step 4): copy carnotpb cols → vizierpb cols. The
+      // wire encoding differs (carnot uses RowBatchData inline, vizier
+      // wraps it in QueryData → RowBatchData with per-Column variants), so
+      // it's a per-type translation. Schema headers already give the client
+      // enough to recognise the response shape.
+    }
+    if (chunk.has_execution_error() && chunk.execution_error().err_code() != 0) {
+      auto* status = resp.mutable_status();
+      status->set_message(chunk.execution_error().msg());
+    }
+    writer->Write(resp);
+  }
+}
+
+}  // namespace
+
 ::grpc::Status DirectQueryServer::ExecuteScript(
     ::grpc::ServerContext* context, const ::px::api::vizierpb::ExecuteScriptRequest* request,
     ::grpc::ServerWriter<::px::api::vizierpb::ExecuteScriptResponse>* writer) {
@@ -234,17 +336,41 @@ std::string hmacSha256(absl::string_view key, absl::string_view data) {
     return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED,
                           "direct-query: mutations out of scope (#29)");
   }
-  // Members are placeholders until Step 2 ports the standalone_pem exec path;
-  // touch them to keep -Wunused-private-field happy under -Werror.
-  (void)writer;
-  (void)carnot_;
-  (void)engine_state_;
-  (void)result_server_;
-  // TODO(pem-agent): port the standalone_pem VizierServer execution path — compile
-  // the PxL via engine_state_->CreateLocalExecutionCompilerState, run on carnot_,
-  // stream the result table(s) as ExecuteScriptResponse rows.
-  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED,
-                        "direct-query: ExecuteScript not implemented (#29)");
+  // Defensive: any of carnot_/engine_state_/result_server_ being null at this
+  // point means the operator deploy is misconfigured. Refuse rather than crash.
+  if (carnot_ == nullptr || engine_state_ == nullptr || result_server_ == nullptr) {
+    return ::grpc::Status(::grpc::StatusCode::FAILED_PRECONDITION,
+                          "direct-query: server not wired with a live Carnot");
+  }
+  const auto query_id = sole::uuid4();
+  const std::string query_id_str = query_id.str();
+
+  // Compile to inspect the plan + emit schema headers, mirroring
+  // standalone_pem/vizier_server.h:121-173.
+  auto compiler_state = engine_state_->CreateLocalExecutionCompilerState(0);
+  auto plan_or = ::px::carnot::planner::compiler::Compiler().Compile(request->query_str(),
+                                                                     compiler_state.get());
+  if (!plan_or.ok()) {
+    auto msg = absl::Substitute("direct-query: PxL compile failed ($0)", plan_or.msg());
+    VLOG(1) << msg;
+    return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT, msg);
+  }
+  const auto plan = plan_or.ConsumeValueOrDie();
+  emitSchemaResponses(plan, query_id_str, writer);
+
+  // Reset the sink so we only see chunks for THIS query, then execute.
+  // Synchronous: Carnot::ExecuteQuery blocks until the plan finishes (same as
+  // standalone_pem + carnot_test).
+  result_server_->ResetQueryResults();
+  auto exec_s = carnot_->ExecuteQuery(request->query_str(), query_id, ::px::CurrentTimeNS());
+  if (!exec_s.ok()) {
+    auto msg =
+        absl::Substitute("direct-query: PxL execute failed ($0)", exec_s.msg());
+    VLOG(1) << msg;
+    return ::grpc::Status(::grpc::StatusCode::INTERNAL, msg);
+  }
+  drainSinkAndStream(result_server_, query_id_str, writer);
+  return ::grpc::Status::OK;
 }
 
 }  // namespace agent

--- a/src/vizier/services/agent/pem/direct_query_server.cc
+++ b/src/vizier/services/agent/pem/direct_query_server.cc
@@ -172,8 +172,26 @@ std::string hmacSha256(absl::string_view key, absl::string_view data) {
     return ::grpc::Status(::grpc::StatusCode::UNAUTHENTICATED,
                           "direct-query: payload not a JSON object");
   }
-  if (!payload.HasMember("aud") || !payload["aud"].IsString() ||
-      std::strcmp(payload["aud"].GetString(), kExpectedAudience) != 0) {
+  // RFC 7519 §4.1.3 — `aud` may be a single string OR an array of strings. The
+  // pixie-wide mint path (src/shared/services/utils/jwt.go:46) emits the array
+  // form (`"aud":["vizier"]`), and kelvin / query-broker verifiers accept both;
+  // we do the same so dx's live tokens authenticate against this verifier.
+  if (!payload.HasMember("aud")) {
+    return ::grpc::Status(::grpc::StatusCode::UNAUTHENTICATED, "direct-query: missing aud claim");
+  }
+  const auto& aud = payload["aud"];
+  bool aud_ok = false;
+  if (aud.IsString() && std::strcmp(aud.GetString(), kExpectedAudience) == 0) {
+    aud_ok = true;
+  } else if (aud.IsArray()) {
+    for (const auto& v : aud.GetArray()) {
+      if (v.IsString() && std::strcmp(v.GetString(), kExpectedAudience) == 0) {
+        aud_ok = true;
+        break;
+      }
+    }
+  }
+  if (!aud_ok) {
     return ::grpc::Status(::grpc::StatusCode::UNAUTHENTICATED,
                           "direct-query: wrong audience (expected vizier)");
   }
@@ -261,9 +279,8 @@ namespace {
 // ExecuteScriptResponse per GRPC_SINK_OPERATOR sink. The client uses these to
 // learn output table names and column types before the data chunks arrive.
 // Mirrors standalone_pem/vizier_server.h:132-173.
-void emitSchemaResponses(
-    const ::px::carnot::planpb::Plan& plan, const std::string& query_id,
-    ::grpc::ServerWriter<::px::api::vizierpb::ExecuteScriptResponse>* writer) {
+void emitSchemaResponses(const ::px::carnot::planpb::Plan& plan, const std::string& query_id,
+                         ::grpc::ServerWriter<::px::api::vizierpb::ExecuteScriptResponse>* writer) {
   for (const auto& f : plan.nodes()) {
     for (const auto& n : f.nodes()) {
       if (n.op().op_type() != ::px::carnot::planpb::OperatorType::GRPC_SINK_OPERATOR) continue;
@@ -291,30 +308,37 @@ void emitSchemaResponses(
 // standalone_pem/sink_server.h:60-105 but operates on already-collected
 // chunks rather than a streaming consumer.
 //
-// Step 2b emits one minimal-but-valid response per chunk so the contract test
-// (which only asserts OK + >=1 response) goes green. Full column-marshaling
-// from carnotpb::RowBatchData to vizierpb::RowBatchData (cols.{data,type})
-// lands when the dx-side consumer is wired in Step 4's live e2e; the column
-// payloads are non-trivial cross-proto translation, and the schema headers
-// emitted before this drain already give the client column metadata.
-void drainSinkAndStream(
-    ::px::carnot::exec::LocalGRPCResultSinkServer* result_server, const std::string& query_id,
-    ::grpc::ServerWriter<::px::api::vizierpb::ExecuteScriptResponse>* writer) {
+// Per-row column data is copied by wire-format round-trip: carnotpb's and
+// vizierpb's Column messages are bytewise identical (same oneof tags + field
+// numbers for boolean/int64/uint128/time64ns/float64/string), and the
+// surrounding RowBatchData shares field numbers 1-4 (cols/num_rows/eow/eos);
+// vizier's table_id sits at field 5 which carnot doesn't emit and we set
+// explicitly from query_result().table_name(). dx-agent confirmed this
+// envelope is what pxapi's TableMuxer/HandleRecord consumes.
+void drainSinkAndStream(::px::carnot::exec::LocalGRPCResultSinkServer* result_server,
+                        const std::string& query_id,
+                        ::grpc::ServerWriter<::px::api::vizierpb::ExecuteScriptResponse>* writer) {
   for (const auto& chunk : result_server->raw_query_results()) {
     ::px::api::vizierpb::ExecuteScriptResponse resp;
     resp.set_query_id(query_id);
     if (chunk.has_query_result() && chunk.query_result().has_row_batch()) {
       const auto& src = chunk.query_result().row_batch();
       auto* batch = resp.mutable_data()->mutable_batch();
-      batch->set_table_id(chunk.query_result().table_name());
-      batch->set_num_rows(src.num_rows());
-      batch->set_eow(src.eow());
-      batch->set_eos(src.eos());
-      // TODO(pem-agent / Step 4): copy carnotpb cols → vizierpb cols. The
-      // wire encoding differs (carnot uses RowBatchData inline, vizier
-      // wraps it in QueryData → RowBatchData with per-Column variants), so
-      // it's a per-type translation. Schema headers already give the client
-      // enough to recognise the response shape.
+      // Wire-compatible round-trip: serialize the carnot RowBatchData, parse
+      // into the vizier message. cols / num_rows / eow / eos all land verbatim
+      // (matching field numbers + identical Column oneof layout).
+      std::string buf;
+      if (src.SerializeToString(&buf) && batch->ParseFromString(buf)) {
+        batch->set_table_id(chunk.query_result().table_name());
+      } else {
+        // Roundtrip failed — should never happen on a well-formed payload, but
+        // fall back to the metadata-only shape so the client at least sees the
+        // batch boundary.
+        batch->set_table_id(chunk.query_result().table_name());
+        batch->set_num_rows(src.num_rows());
+        batch->set_eow(src.eow());
+        batch->set_eos(src.eos());
+      }
     }
     if (chunk.has_execution_error() && chunk.execution_error().err_code() != 0) {
       auto* status = resp.mutable_status();
@@ -364,8 +388,7 @@ void drainSinkAndStream(
   result_server_->ResetQueryResults();
   auto exec_s = carnot_->ExecuteQuery(request->query_str(), query_id, ::px::CurrentTimeNS());
   if (!exec_s.ok()) {
-    auto msg =
-        absl::Substitute("direct-query: PxL execute failed ($0)", exec_s.msg());
+    auto msg = absl::Substitute("direct-query: PxL execute failed ($0)", exec_s.msg());
     VLOG(1) << msg;
     return ::grpc::Status(::grpc::StatusCode::INTERNAL, msg);
   }

--- a/src/vizier/services/agent/pem/direct_query_server.cc
+++ b/src/vizier/services/agent/pem/direct_query_server.cc
@@ -308,41 +308,67 @@ void emitSchemaResponses(const ::px::carnot::planpb::Plan& plan, const std::stri
 // standalone_pem/sink_server.h:60-105 but operates on already-collected
 // chunks rather than a streaming consumer.
 //
-// Per-row column data is copied by wire-format round-trip: carnotpb's and
-// vizierpb's Column messages are bytewise identical (same oneof tags + field
-// numbers for boolean/int64/uint128/time64ns/float64/string), and the
-// surrounding RowBatchData shares field numbers 1-4 (cols/num_rows/eow/eos);
-// vizier's table_id sits at field 5 which carnot doesn't emit and we set
-// explicitly from query_result().table_name(). dx-agent confirmed this
-// envelope is what pxapi's TableMuxer/HandleRecord consumes.
+// Per-row column data + exec stats are copied by wire-format round-trip:
+// carnotpb's and vizierpb's Column messages are bytewise identical (same oneof
+// tags + field numbers for boolean/int64/uint128/time64ns/float64/string), the
+// surrounding RowBatchData shares field numbers 1-4 (cols/num_rows/eow/eos),
+// and QueryExecutionStats shares field 1 (timing) / 2 (bytes_processed) /
+// 3 (records_processed). Wire-format roundtrip carries the data without a
+// per-type switch; vizier-only RowBatchData.table_id (field 5) is set
+// explicitly.
+//
+// **Don't write empty responses.** pxapi/results.go:142-143 returns
+// "unimplemented type : internal error" when an ExecuteScriptResponse has
+// neither meta_data, data.batch, data.encrypted_batch, nor data.execution_stats
+// set. Carnot's sink emits chunks that are neither query_result nor
+// execution_error (e.g. initiate_conn). Skip those instead of writing
+// query_id-only frames — that was the live e2e bug dx-agent caught on pemdq3.
 void drainSinkAndStream(::px::carnot::exec::LocalGRPCResultSinkServer* result_server,
                         const std::string& query_id,
                         ::grpc::ServerWriter<::px::api::vizierpb::ExecuteScriptResponse>* writer) {
   for (const auto& chunk : result_server->raw_query_results()) {
     ::px::api::vizierpb::ExecuteScriptResponse resp;
     resp.set_query_id(query_id);
+    bool has_payload = false;
+
     if (chunk.has_query_result() && chunk.query_result().has_row_batch()) {
       const auto& src = chunk.query_result().row_batch();
       auto* batch = resp.mutable_data()->mutable_batch();
-      // Wire-compatible round-trip: serialize the carnot RowBatchData, parse
-      // into the vizier message. cols / num_rows / eow / eos all land verbatim
-      // (matching field numbers + identical Column oneof layout).
       std::string buf;
       if (src.SerializeToString(&buf) && batch->ParseFromString(buf)) {
         batch->set_table_id(chunk.query_result().table_name());
       } else {
-        // Roundtrip failed — should never happen on a well-formed payload, but
-        // fall back to the metadata-only shape so the client at least sees the
-        // batch boundary.
+        // Roundtrip failed — should never happen on a well-formed payload,
+        // fall back to the metadata-only shape so the client at least sees
+        // the batch boundary.
         batch->set_table_id(chunk.query_result().table_name());
         batch->set_num_rows(src.num_rows());
         batch->set_eow(src.eow());
         batch->set_eos(src.eos());
       }
+      has_payload = true;
     }
+
+    if (chunk.has_execution_and_timing_info() &&
+        chunk.execution_and_timing_info().has_execution_stats()) {
+      const auto& src_stats = chunk.execution_and_timing_info().execution_stats();
+      auto* dst_stats = resp.mutable_data()->mutable_execution_stats();
+      std::string buf;
+      (void)(src_stats.SerializeToString(&buf) && dst_stats->ParseFromString(buf));
+      has_payload = true;
+    }
+
     if (chunk.has_execution_error() && chunk.execution_error().err_code() != 0) {
       auto* status = resp.mutable_status();
       status->set_message(chunk.execution_error().msg());
+      has_payload = true;
+    }
+
+    if (!has_payload) {
+      // initiate_conn or any future variant we haven't mapped — pxapi rejects
+      // payload-less ExecuteScriptResponses as ErrInternalUnImplementedType.
+      // Skipping preserves stream OK.
+      continue;
     }
     writer->Write(resp);
   }

--- a/src/vizier/services/agent/pem/direct_query_server.cc
+++ b/src/vizier/services/agent/pem/direct_query_server.cc
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// STUB IMPLEMENTATION — entlein/dx#29. Deliberately the TDD "red" state: auth
+// fails closed and ExecuteScript is UNIMPLEMENTED so direct_query_server_test.cc
+// fails on the execution-path cases until the pem-agent ports the real logic from
+// src/experimental/standalone_pem/vizier_server.h (against the live Carnot) and
+// implements JWT verification.
+
+#include "src/vizier/services/agent/pem/direct_query_server.h"
+
+#include <string>
+
+namespace px {
+namespace vizier {
+namespace agent {
+
+::grpc::Status AuthenticateRequest(::grpc::ServerContext* ctx, const std::string& jwt_signing_key) {
+  // Fail closed: with no real verification yet, every call is unauthenticated.
+  // This already satisfies the "missing/invalid token → UNAUTHENTICATED" cases.
+  // TODO(pem-agent): extract the bearer token from ctx->client_metadata()
+  // ("authorization"), verify HS256 signature against jwt_signing_key, check exp
+  // and the vizier audience, and return OK only then. Use src/shared/services/utils.
+  (void)ctx;
+  (void)jwt_signing_key;
+  return ::grpc::Status(::grpc::StatusCode::UNAUTHENTICATED, "direct-query: auth not implemented (#29)");
+}
+
+::grpc::Status DirectQueryServer::ExecuteScript(
+    ::grpc::ServerContext* context, const ::px::api::vizierpb::ExecuteScriptRequest* request,
+    ::grpc::ServerWriter<::px::api::vizierpb::ExecuteScriptResponse>* writer) {
+  if (auto s = AuthenticateRequest(context, jwt_signing_key_); !s.ok()) {
+    return s;
+  }
+  if (request->mutation()) {
+    return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "direct-query: mutations out of scope (#29)");
+  }
+  (void)writer;
+  // TODO(pem-agent): port the standalone_pem VizierServer execution path — compile
+  // the PxL via engine_state_->CreateLocalExecutionCompilerState, run on carnot_,
+  // stream the result table(s) as ExecuteScriptResponse rows.
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "direct-query: ExecuteScript not implemented (#29)");
+}
+
+}  // namespace agent
+}  // namespace vizier
+}  // namespace px

--- a/src/vizier/services/agent/pem/direct_query_server.cc
+++ b/src/vizier/services/agent/pem/direct_query_server.cc
@@ -23,6 +23,12 @@
 
 #include "src/vizier/services/agent/pem/direct_query_server.h"
 
+// Note: stdlib + boringssl + rapidjson + absl includes stay at the top
+// (not inside the `#ifndef` below) because cpplint's
+// build/include_what_you_use scan doesn't follow preprocessor branches
+// and would otherwise flag every type used in the feature body as
+// "missing include". The disabled build pays a few KB of unused header
+// parse cost; the .cc emits nothing for them.
 #include <openssl/hmac.h>
 #include <openssl/sha.h>
 #include <rapidjson/document.h>
@@ -38,6 +44,16 @@
 #include <absl/strings/string_view.h>
 #include <absl/strings/substitute.h>
 #include <sole.hpp>
+
+// Compile-time kill switch. When PX_PEM_DIRECT_QUERY_DISABLED is defined
+// (passed via the //src/vizier/services/agent/pem:direct_query=disabled
+// config_setting in BUILD.bazel), the entire feature-bearing body of this
+// file — JWT verifier, Carnot exec path — is EXCLUDED. The
+// DirectQueryServer class still resolves at link time (so callers don't
+// break) but every public function returns UNAUTHENTICATED/UNIMPLEMENTED.
+// Operators get a binary with zero direct-query feature code. See
+// DIRECT_QUERY_SECURITY.md "Disabling the feature".
+#ifndef PX_PEM_DIRECT_QUERY_DISABLED
 
 #include "src/carnot/carnot.h"
 #include "src/carnot/carnotpb/carnot.pb.h"
@@ -425,3 +441,42 @@ void drainSinkAndStream(::px::carnot::exec::LocalGRPCResultSinkServer* result_se
 }  // namespace agent
 }  // namespace vizier
 }  // namespace px
+
+#else  // PX_PEM_DIRECT_QUERY_DISABLED
+
+// Compile-out stubs. Linker-satisfying definitions of the two public
+// surfaces with zero feature behaviour. Includes deliberately minimal —
+// no openssl, no rapidjson, no carnot — so a "feature disabled" build
+// carries no direct-query attack surface in the binary.
+
+namespace px {
+namespace vizier {
+namespace agent {
+
+::grpc::Status AuthenticateRequest(::grpc::ServerContext*, const std::string&) {
+  return ::grpc::Status(::grpc::StatusCode::UNAUTHENTICATED,
+                        "direct-query: compiled out of this build "
+                        "(PX_PEM_DIRECT_QUERY_DISABLED)");
+}
+
+::grpc::Status DirectQueryServer::ExecuteScript(
+    ::grpc::ServerContext*, const ::px::api::vizierpb::ExecuteScriptRequest*,
+    ::grpc::ServerWriter<::px::api::vizierpb::ExecuteScriptResponse>*) {
+  // Reference the unused private fields so -Wunused-private-field doesn't
+  // flag the disabled build. The class signature is the same in both modes
+  // (so callers see one type); we just don't drive any work from these
+  // pointers in the disabled stub.
+  (void)carnot_;
+  (void)engine_state_;
+  (void)result_server_;
+  (void)jwt_signing_key_;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED,
+                        "direct-query: compiled out of this build "
+                        "(PX_PEM_DIRECT_QUERY_DISABLED)");
+}
+
+}  // namespace agent
+}  // namespace vizier
+}  // namespace px
+
+#endif  // PX_PEM_DIRECT_QUERY_DISABLED

--- a/src/vizier/services/agent/pem/direct_query_server.cc
+++ b/src/vizier/services/agent/pem/direct_query_server.cc
@@ -74,7 +74,9 @@ constexpr char kBearerPrefixLower[] = "bearer ";
 constexpr size_t kBearerPrefixLen = sizeof(kBearerPrefixLower) - 1;
 constexpr char kExpectedAudience[] = "vizier";
 constexpr char kExpectedIssuer[] = "PL";
-constexpr char kExpectedSubject[] = "service";
+// Service tokens carry "service" in the Scopes claim (NOT the subject — sub is
+// the serviceID, e.g. "dx"). See GenerateJWTForService (claims.go) + jwt.go:56.
+constexpr char kServiceScope[] = "service";
 
 // We don't link cpp_jwt's HMAC verifier here because its impl calls
 // BIO_f_base64() which lives in BoringSSL's decrepit/ tree — not exposed as a
@@ -218,10 +220,27 @@ std::string hmacSha256(absl::string_view key, absl::string_view data) {
     return ::grpc::Status(::grpc::StatusCode::UNAUTHENTICATED,
                           "direct-query: wrong iss (expected PL)");
   }
-  if (!payload.HasMember("sub") || !payload["sub"].IsString() ||
-      std::strcmp(payload["sub"].GetString(), kExpectedSubject) != 0) {
+  // Require the "service" scope, NOT sub=="service". Pixie service tokens set
+  // sub=<serviceID> (e.g. "dx") and put "service" in the Scopes claim — a
+  // comma-joined string (GenerateJWTForService in claims.go + jwt.go:56). The
+  // canonical verifier (jwt.go ParseToken) authenticates on signature+audience
+  // and never asserts the subject; checking the scope rejects user/cluster
+  // tokens while accepting any serviceID subject. (Previously this rejected
+  // every real in-cluster caller with "wrong sub".)
+  if (!payload.HasMember("Scopes") || !payload["Scopes"].IsString()) {
     return ::grpc::Status(::grpc::StatusCode::UNAUTHENTICATED,
-                          "direct-query: wrong sub (expected service)");
+                          "direct-query: missing Scopes claim");
+  }
+  bool has_service_scope = false;
+  for (absl::string_view scope : absl::StrSplit(payload["Scopes"].GetString(), ',')) {
+    if (scope == kServiceScope) {
+      has_service_scope = true;
+      break;
+    }
+  }
+  if (!has_service_scope) {
+    return ::grpc::Status(::grpc::StatusCode::UNAUTHENTICATED,
+                          "direct-query: token lacks the service scope");
   }
   if (!payload.HasMember("exp")) {
     return ::grpc::Status(::grpc::StatusCode::UNAUTHENTICATED, "direct-query: missing exp claim");

--- a/src/vizier/services/agent/pem/direct_query_server.cc
+++ b/src/vizier/services/agent/pem/direct_query_server.cc
@@ -38,7 +38,8 @@ namespace agent {
   // and the vizier audience, and return OK only then. Use src/shared/services/utils.
   (void)ctx;
   (void)jwt_signing_key;
-  return ::grpc::Status(::grpc::StatusCode::UNAUTHENTICATED, "direct-query: auth not implemented (#29)");
+  return ::grpc::Status(::grpc::StatusCode::UNAUTHENTICATED,
+                        "direct-query: auth not implemented (#29)");
 }
 
 ::grpc::Status DirectQueryServer::ExecuteScript(
@@ -48,13 +49,19 @@ namespace agent {
     return s;
   }
   if (request->mutation()) {
-    return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "direct-query: mutations out of scope (#29)");
+    return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED,
+                          "direct-query: mutations out of scope (#29)");
   }
+  // Members are placeholders until Step 2 ports the standalone_pem exec path;
+  // touch them to keep -Wunused-private-field happy under -Werror.
   (void)writer;
+  (void)carnot_;
+  (void)engine_state_;
   // TODO(pem-agent): port the standalone_pem VizierServer execution path — compile
   // the PxL via engine_state_->CreateLocalExecutionCompilerState, run on carnot_,
   // stream the result table(s) as ExecuteScriptResponse rows.
-  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "direct-query: ExecuteScript not implemented (#29)");
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED,
+                        "direct-query: ExecuteScript not implemented (#29)");
 }
 
 }  // namespace agent

--- a/src/vizier/services/agent/pem/direct_query_server.h
+++ b/src/vizier/services/agent/pem/direct_query_server.h
@@ -40,6 +40,9 @@ namespace px {
 namespace carnot {
 class Carnot;
 class EngineState;
+namespace exec {
+class LocalGRPCResultSinkServer;
+}  // namespace exec
 }  // namespace carnot
 
 namespace vizier {
@@ -49,20 +52,28 @@ namespace agent {
 // incoming call against `jwt_signing_key` (HS256, unexpired, vizier-audience).
 // Returns OK iff the token is valid; UNAUTHENTICATED otherwise. A missing token
 // MUST NOT fall through to execution. See DIRECT_QUERY_CONTRACT.md § Auth.
-//
-// TODO(pem-agent): implement using src/shared/services/utils JWT verification.
 ::grpc::Status AuthenticateRequest(::grpc::ServerContext* ctx, const std::string& jwt_signing_key);
 
 // DirectQueryServer serves api.vizierpb.VizierService.ExecuteScript directly on the
 // PEM, authenticated, against the live node-local Carnot. Construct with the PEM's
 // already-running engine — do not create a new one.
+//
+// `result_server` is the sink Carnot is configured to push results into; the
+// server polls it after `ExecuteQuery` returns and converts the accumulated
+// `TransferResultChunkRequest`s into streamed `ExecuteScriptResponse`s. Used
+// the same way standalone_pem's VizierServer does, except with the live PEM's
+// Carnot wired in production (see Step 4) and a CarnotTest-style fixture in
+// unit tests. Pass nullptr to disable the execution path (used by auth-only
+// tests so they don't need to stand up a TableStore).
 class DirectQueryServer final : public api::vizierpb::VizierService::Service {
  public:
   DirectQueryServer() = delete;
   DirectQueryServer(carnot::Carnot* carnot, carnot::EngineState* engine_state,
+                    carnot::exec::LocalGRPCResultSinkServer* result_server,
                     std::string jwt_signing_key)
       : carnot_(carnot),
         engine_state_(engine_state),
+        result_server_(result_server),
         jwt_signing_key_(std::move(jwt_signing_key)) {}
 
   // ExecuteScript: authenticate, then run the PxL on the local Carnot and stream
@@ -74,6 +85,7 @@ class DirectQueryServer final : public api::vizierpb::VizierService::Service {
  private:
   carnot::Carnot* carnot_;
   carnot::EngineState* engine_state_;
+  carnot::exec::LocalGRPCResultSinkServer* result_server_;
   std::string jwt_signing_key_;
 };
 

--- a/src/vizier/services/agent/pem/direct_query_server.h
+++ b/src/vizier/services/agent/pem/direct_query_server.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Direct-query gRPC endpoint for the normal (metadata-connected) PEM — entlein/dx#29.
+//
+// STUB: dx-agent provides this interface + the TDD contract in
+// direct_query_server_test.cc and DIRECT_QUERY_CONTRACT.md. The pem-agent (build VM)
+// implements the bodies in direct_query_server.cc against the PEM's existing Carnot.
+//
+// Reference impl to port from: src/experimental/standalone_pem/vizier_server.h
+// (px::vizier::agent::VizierServer). Differences for the real PEM: reuse the live
+// Carnot + metadata (no second engine), and REQUIRE a valid cluster service JWT.
+
+#pragma once
+
+#include <grpcpp/grpcpp.h>
+#include <memory>
+#include <string>
+
+#include "src/api/proto/vizierpb/vizierapi.grpc.pb.h"
+#include "src/api/proto/vizierpb/vizierapi.pb.h"
+
+namespace px {
+namespace carnot {
+class Carnot;
+class EngineState;
+}  // namespace carnot
+
+namespace vizier {
+namespace agent {
+
+// AuthenticateRequest verifies the `authorization: Bearer <jwt>` metadata on an
+// incoming call against `jwt_signing_key` (HS256, unexpired, vizier-audience).
+// Returns OK iff the token is valid; UNAUTHENTICATED otherwise. A missing token
+// MUST NOT fall through to execution. See DIRECT_QUERY_CONTRACT.md § Auth.
+//
+// TODO(pem-agent): implement using src/shared/services/utils JWT verification.
+::grpc::Status AuthenticateRequest(::grpc::ServerContext* ctx, const std::string& jwt_signing_key);
+
+// DirectQueryServer serves api.vizierpb.VizierService.ExecuteScript directly on the
+// PEM, authenticated, against the live node-local Carnot. Construct with the PEM's
+// already-running engine — do not create a new one.
+class DirectQueryServer final : public api::vizierpb::VizierService::Service {
+ public:
+  DirectQueryServer() = delete;
+  DirectQueryServer(carnot::Carnot* carnot, carnot::EngineState* engine_state,
+                    std::string jwt_signing_key)
+      : carnot_(carnot), engine_state_(engine_state), jwt_signing_key_(std::move(jwt_signing_key)) {}
+
+  // ExecuteScript: authenticate, then run the PxL on the local Carnot and stream
+  // ExecuteScriptResponse rows. Mutations are out of scope (return UNIMPLEMENTED).
+  ::grpc::Status ExecuteScript(
+      ::grpc::ServerContext* context, const ::px::api::vizierpb::ExecuteScriptRequest* request,
+      ::grpc::ServerWriter<::px::api::vizierpb::ExecuteScriptResponse>* writer) override;
+
+ private:
+  carnot::Carnot* carnot_;
+  carnot::EngineState* engine_state_;
+  std::string jwt_signing_key_;
+};
+
+}  // namespace agent
+}  // namespace vizier
+}  // namespace px

--- a/src/vizier/services/agent/pem/direct_query_server.h
+++ b/src/vizier/services/agent/pem/direct_query_server.h
@@ -33,6 +33,8 @@
 #include <string>
 #include <utility>  // std::move (used in DirectQueryServer ctor)
 
+#include <absl/synchronization/mutex.h>
+
 #include "src/api/proto/vizierpb/vizierapi.grpc.pb.h"
 #include "src/api/proto/vizierpb/vizierapi.pb.h"
 
@@ -87,6 +89,15 @@ class DirectQueryServer final : public api::vizierpb::VizierService::Service {
   carnot::EngineState* engine_state_;
   carnot::exec::LocalGRPCResultSinkServer* result_server_;
   std::string jwt_signing_key_;
+
+  // exec_mu_ serializes the ResetQueryResults / ExecuteQuery /
+  // drainSinkAndStream critical section. The LocalGRPCResultSinkServer's
+  // accumulator is shared mutable state: a concurrent ExecuteScript call
+  // would clear or interleave another caller's chunks if not protected
+  // (CodeRabbit r3364645000 catch). Per-instance (not file-scope) so
+  // distinct DirectQueryServer instances in tests don't over-serialize
+  // against each other.
+  mutable absl::Mutex exec_mu_;
 };
 
 }  // namespace agent

--- a/src/vizier/services/agent/pem/direct_query_server.h
+++ b/src/vizier/services/agent/pem/direct_query_server.h
@@ -31,6 +31,7 @@
 #include <grpcpp/grpcpp.h>
 #include <memory>
 #include <string>
+#include <utility>  // std::move (used in DirectQueryServer ctor)
 
 #include "src/api/proto/vizierpb/vizierapi.grpc.pb.h"
 #include "src/api/proto/vizierpb/vizierapi.pb.h"
@@ -60,7 +61,9 @@ class DirectQueryServer final : public api::vizierpb::VizierService::Service {
   DirectQueryServer() = delete;
   DirectQueryServer(carnot::Carnot* carnot, carnot::EngineState* engine_state,
                     std::string jwt_signing_key)
-      : carnot_(carnot), engine_state_(engine_state), jwt_signing_key_(std::move(jwt_signing_key)) {}
+      : carnot_(carnot),
+        engine_state_(engine_state),
+        jwt_signing_key_(std::move(jwt_signing_key)) {}
 
   // ExecuteScript: authenticate, then run the PxL on the local Carnot and stream
   // ExecuteScriptResponse rows. Mutations are out of scope (return UNIMPLEMENTED).

--- a/src/vizier/services/agent/pem/direct_query_server_test.cc
+++ b/src/vizier/services/agent/pem/direct_query_server_test.cc
@@ -26,10 +26,13 @@
 // The fixture runs an in-process gRPC server hosting DirectQueryServer and a real
 // client stub, so authorization metadata flows exactly as in production.
 
-#include <grpcpp/grpcpp.h>
-#include <grpcpp/security/server_credentials.h>
+#include <chrono>
 #include <memory>
 #include <string>
+
+#include <grpcpp/grpcpp.h>
+#include <grpcpp/security/server_credentials.h>
+#include <jwt/jwt.hpp>
 
 #include "src/api/proto/vizierpb/vizierapi.grpc.pb.h"
 #include "src/common/testing/testing.h"
@@ -44,28 +47,34 @@ constexpr char kWrongSigningKey[] = "a-different-key";
 
 enum class TokenKind { kValid, kWrongKey, kExpired };
 
-// MakeBearerToken returns a JWT for the in-process call's `authorization` metadata.
-// TODO(pem-agent): implement to match the C++ verifier in AuthenticateRequest —
-// kValid: HS256 over `signing_key`, unexpired, vizier audience (mirror the Go
-// GenerateJWTForService("dx","vizier") claims in src/shared/services/utils);
-// kWrongKey: signed with a different key; kExpired: valid signature but exp in the
-// past. The token-maker and the verifier are a matched pair you own.
+// MakeBearerToken mints a JWT for the in-process call's `authorization` metadata,
+// matching the verifier in AuthenticateRequest. Claim shape mirrors
+// src/vizier/services/agent/shared/manager/manager.cc::GenerateServiceToken —
+// HS256 / iss=PL / aud=vizier / iat,nbf,exp / sub=service. The token-maker and
+// the verifier are a matched pair.
 //
-// Placeholder body so the test BUILDS + LINKS today: it returns a non-empty
-// non-JWT string, which the fail-closed stub verifier rejects → the auth-negative
-// cases pass for the right reason, and ValidToken_* stays red until you implement
-// both this maker and AuthenticateRequest.
+// - kValid:    signed with `signing_key`, exp +60s
+// - kWrongKey: signed with `signing_key` argument — caller passes the wrong key
+//              so the resulting token won't verify against the server's key
+// - kExpired:  signed with `signing_key`, exp 60s in the past
 std::string MakeBearerToken(const std::string& signing_key, TokenKind kind) {
-  (void)signing_key;
-  switch (kind) {
-    case TokenKind::kValid:
-      return "PLACEHOLDER.valid.token";  // TODO(pem-agent): real signed JWT
-    case TokenKind::kWrongKey:
-      return "PLACEHOLDER.wrongkey.token";
-    case TokenKind::kExpired:
-      return "PLACEHOLDER.expired.token";
-  }
-  return "";
+  using std::chrono::seconds;
+  using std::chrono::system_clock;
+  auto now = system_clock::now();
+  auto exp_offset = (kind == TokenKind::kExpired) ? seconds{-60} : seconds{60};
+
+  jwt::jwt_object obj{jwt::params::algorithm("HS256")};
+  obj.add_claim("iss", "PL");
+  obj.add_claim("aud", "vizier");
+  obj.add_claim("jti", "direct-query-test");
+  obj.add_claim("iat", now);
+  obj.add_claim("nbf", now - seconds{60});
+  obj.add_claim("exp", now + exp_offset);
+  obj.add_claim("sub", "service");
+  obj.add_claim("Scopes", "service");
+  obj.add_claim("ServiceID", "dx-test");
+  obj.secret(signing_key);
+  return obj.signature();
 }
 
 // Test fixture: in-process server hosting DirectQueryServer + a client stub.

--- a/src/vizier/services/agent/pem/direct_query_server_test.cc
+++ b/src/vizier/services/agent/pem/direct_query_server_test.cc
@@ -63,14 +63,14 @@ constexpr char kWrongSigningKey[] = "a-different-key";
 // the verifier ignores those claims; minting them differently doesn't
 // change auth outcomes and would produce misleading test names.
 enum class TokenKind {
-  kValid,           // signed with `signing_key`, exp +60s, aud=["vizier"]
-  kWrongKey,        // signed with caller's signing_key; caller passes the wrong key to MakeBearerToken
-  kExpired,         // signed correctly, exp -60s
-  kAudAsString,     // signed correctly, aud="vizier" (string, not array — backwards compat path)
-  kMissingAud,      // signed correctly, no aud claim
-  kWrongAud,        // signed correctly, aud=["wrong-service"]
-  kMissingExp,      // signed correctly, no exp claim (verifier requires exp)
-  kAlgNone,         // alg=none header forgery (verifier must reject — refuses anything but HS256)
+  kValid,        // signed with `signing_key`, exp +60s, aud=["vizier"]
+  kWrongKey,     // signed with caller's signing_key; caller passes the wrong key to MakeBearerToken
+  kExpired,      // signed correctly, exp -60s
+  kAudAsString,  // signed correctly, aud="vizier" (string, not array — backwards compat path)
+  kMissingAud,   // signed correctly, no aud claim
+  kWrongAud,     // signed correctly, aud=["wrong-service"]
+  kMissingExp,   // signed correctly, no exp claim (verifier requires exp)
+  kAlgNone,      // alg=none header forgery (verifier must reject — refuses anything but HS256)
 };
 
 // MakeBearerToken mints a JWT for the in-process call's `authorization` metadata,
@@ -278,9 +278,9 @@ TEST_F(DirectQueryServerTest, BearerEmptyToken_Unauthenticated) {
 // explicitly lowercase-compares the scheme to be defensive).
 TEST_F(DirectQueryServerTest, ValidToken_LowercaseBearerPrefix_Authenticated) {
   auto tok = MakeBearerToken(kTestSigningKey, TokenKind::kValid);
-  auto status = CallExecuteScriptRaw("bearer " + tok,
-                                     "import px\npx.display(px.DataFrame('http_events'))")
-                    .error_code();
+  auto status =
+      CallExecuteScriptRaw("bearer " + tok, "import px\npx.display(px.DataFrame('http_events'))")
+          .error_code();
   EXPECT_NE(::grpc::StatusCode::UNAUTHENTICATED, status)
       << "case-insensitive Bearer scheme must authenticate (e.g. 'bearer <tok>').";
 }
@@ -289,10 +289,10 @@ TEST_F(DirectQueryServerTest, ValidToken_LowercaseBearerPrefix_Authenticated) {
 // the Bearer scheme.
 TEST_F(DirectQueryServerTest, WrongAuthScheme_Unauthenticated) {
   auto tok = MakeBearerToken(kTestSigningKey, TokenKind::kValid);
-  EXPECT_EQ(::grpc::StatusCode::UNAUTHENTICATED,
-            CallExecuteScriptRaw("Token " + tok,
-                                 "import px\npx.display(px.DataFrame('http_events'))")
-                .error_code());
+  EXPECT_EQ(
+      ::grpc::StatusCode::UNAUTHENTICATED,
+      CallExecuteScriptRaw("Token " + tok, "import px\npx.display(px.DataFrame('http_events'))")
+          .error_code());
 }
 
 // ===========================================================================
@@ -759,6 +759,88 @@ TEST_F(DirectQueryServerExecTest, FailSoft_BrokerFailureToleratedByDirectQuery) 
                   "NATS registration; hoist MaybeStartDirectQueryServer or "
                   "introduce a broker-optional Manager mode to close the "
                   "contract. Tracked in DIRECT_QUERY_SECURITY.md.";
+}
+
+// ===========================================================================
+// Feature-toggle effectiveness — covers BOTH the runtime flag (soft toggle)
+// and the compile-time macro (hard toggle). User asks on PR #49:
+//   - "feature toggle being 100% effective in case the feature is not desired"
+//   - "compiler flag that fully disables the feature in case customers do
+//      not want the feature available in the binary"
+//
+// Runtime toggle (--direct_query_enabled=false) is asserted by the fact that
+// pem_manager.cc:MaybeStartDirectQueryServer early-returns Status::OK before
+// any sink/carnot/grpc-server is constructed when the flag is false. The
+// PEMManager unit-test fixture is heavy (Stirling, NATS, etc.) so we don't
+// stand it up here; the visible contract is: the runtime flag's early return
+// short-circuits before line 1 of feature code runs.
+//
+// Compile-time toggle (PX_PEM_DIRECT_QUERY=disabled) is asserted in code
+// below: when compiled with the macro, AuthenticateRequest and
+// DirectQueryServer::ExecuteScript both return
+// UNAUTHENTICATED/UNIMPLEMENTED unconditionally, independent of token or
+// PxL contents. The fixture's auth-only nullptr Carnot is sufficient.
+// ===========================================================================
+
+#ifdef PX_PEM_DIRECT_QUERY_DISABLED
+
+// When compiled with PX_PEM_DIRECT_QUERY_DISABLED, every call must short-
+// circuit to UNAUTHENTICATED (no JWT verification path exists). This
+// includes calls with a valid token — the compile-time toggle is harder
+// than the runtime toggle: not even a valid bearer unlocks anything.
+TEST_F(DirectQueryServerTest, CompiledOut_ValidToken_StillUnauthenticated) {
+  auto tok = MakeBearerToken(kTestSigningKey, TokenKind::kValid);
+  EXPECT_EQ(::grpc::StatusCode::UNAUTHENTICATED, CallExecuteScript(tok).error_code())
+      << "PX_PEM_DIRECT_QUERY_DISABLED build must short-circuit AT auth — no "
+         "valid token can re-enable the feature post-compile.";
+}
+
+TEST_F(DirectQueryServerTest, CompiledOut_NoToken_Unauthenticated) {
+  EXPECT_EQ(::grpc::StatusCode::UNAUTHENTICATED, CallExecuteScript("").error_code());
+}
+
+#else  // PX_PEM_DIRECT_QUERY_DISABLED
+
+// Compile-time toggle is OFF (default build) → the runtime flag is the only
+// guard. This test documents the contract: the *runtime* toggle is the
+// per-deploy soft-disable; the *compile-time* toggle is the per-binary
+// hard-disable. Operators who want zero feature bytes use the compile-time
+// macro; operators who want runtime control use the gflag. Both have the
+// same visible effect (the gRPC service exists in both, but no execution
+// happens) but different binary footprints.
+TEST_F(DirectQueryServerTest, ToggleContract_DocumentBothLevels) {
+  SUCCEED() << "Default build: runtime --direct_query_enabled gates port :50305 "
+               "binding (pem_manager.cc:MaybeStartDirectQueryServer early-returns). "
+               "Compile-time PX_PEM_DIRECT_QUERY=disabled additionally drops all "
+               "feature bytes from the binary (no JWT verifier, no Carnot driver, "
+               "no openssl/rapidjson includes). See DIRECT_QUERY_SECURITY.md.";
+}
+
+#endif  // PX_PEM_DIRECT_QUERY_DISABLED
+
+// ===========================================================================
+// Apples-to-apples benchmark (#29 follow-up). User asks: "create a
+// benchmark test for pem (upstream) vs dual-usage-pem (this PR), clearly
+// profile the root causes of any discrepancies".
+//
+// dx-agent's pemdq5 soak measured ~43.5s/query avg for pemdirect vs ~27s
+// for the broker path, with the second-Carnot exec as the dominant
+// contributor. A proper bench harness requires:
+//   - representative PxL workload (dx pemdirect script + dx broker script)
+//   - controlled cluster (PG with seeded http_events/conn_stats)
+//   - per-call latency histogram + breakdown (auth / compile / exec / drain)
+//   - tech-debt triage with profiled root causes
+//
+// That's out of scope for this PR's unit tests (needs a live cluster +
+// integration harness, not a gtest). Tracked as a follow-up issue; this
+// SKIP names it in code so the gap is greppable.
+// ===========================================================================
+TEST_F(DirectQueryServerExecTest, Benchmark_PemDirect_Vs_BrokerPath_RedPlaceholder) {
+  GTEST_SKIP() << "Follow-up: apples-to-apples bench harness vs the broker path. "
+                  "Soak data on pemdq5 measured pemdirect ~43.5s/q vs broker ~27s/q; "
+                  "dominant factor is the dedicated second Carnot exec on the PEM "
+                  "(shared-Carnot path would close it). Integration-level workload, "
+                  "not a gtest. Tracked in DIRECT_QUERY_SECURITY.md follow-ups.";
 }
 
 }  // namespace agent

--- a/src/vizier/services/agent/pem/direct_query_server_test.cc
+++ b/src/vizier/services/agent/pem/direct_query_server_test.cc
@@ -69,8 +69,8 @@ enum class TokenKind {
   kAlgNone,      // alg=none header forgery (verifier must reject — refuses anything but HS256)
   kWrongIss,     // signed correctly, iss="not-PL"
   kMissingIss,   // signed correctly, no iss claim
-  kWrongSub,     // signed correctly, sub="user"
-  kMissingSub,   // signed correctly, no sub claim
+  kWrongScope,   // signed correctly, Scopes="user" (lacks the service scope)
+  kMissingScope, // signed correctly, no Scopes claim
 };
 
 // MakeBearerToken mints a JWT for the in-process call's `authorization` metadata,
@@ -136,16 +136,18 @@ std::string MakeBearerToken(const std::string& signing_key, TokenKind kind) {
   if (kind != TokenKind::kMissingExp) {
     obj.add_claim("exp", now + exp_offset);
   }
+  // sub is the serviceID (e.g. "dx"), NOT the literal "service" — the verifier
+  // no longer asserts sub; it requires the "service" scope instead.
+  obj.add_claim("sub", "dx");
   switch (kind) {
-    case TokenKind::kWrongSub:
-      obj.add_claim("sub", "user");
+    case TokenKind::kWrongScope:
+      obj.add_claim("Scopes", "user");
       break;
-    case TokenKind::kMissingSub:
+    case TokenKind::kMissingScope:
       break;
     default:
-      obj.add_claim("sub", "service");
+      obj.add_claim("Scopes", "service");
   }
-  obj.add_claim("Scopes", "service");
   obj.add_claim("ServiceID", "dx-test");
   obj.secret(signing_key);
   return obj.signature();
@@ -285,16 +287,17 @@ TEST_F(DirectQueryServerTest, MissingIss_Unauthenticated) {
   EXPECT_EQ(::grpc::StatusCode::UNAUTHENTICATED, CallExecuteScript(tok).error_code());
 }
 
-// Wrong sub → UNAUTHENTICATED. The mint side emits sub="service"; user-scoped
-// tokens (sub="user") must not authenticate against this service-only endpoint.
-TEST_F(DirectQueryServerTest, WrongSub_Unauthenticated) {
-  auto tok = MakeBearerToken(kTestSigningKey, TokenKind::kWrongSub);
+// Wrong scope → UNAUTHENTICATED. Real service tokens carry "service" in the
+// Scopes claim; user-scoped tokens (Scopes="user") must not authenticate against
+// this service-only endpoint. (sub is the serviceID and is not asserted.)
+TEST_F(DirectQueryServerTest, WrongScope_Unauthenticated) {
+  auto tok = MakeBearerToken(kTestSigningKey, TokenKind::kWrongScope);
   EXPECT_EQ(::grpc::StatusCode::UNAUTHENTICATED, CallExecuteScript(tok).error_code());
 }
 
-// No sub claim → UNAUTHENTICATED.
-TEST_F(DirectQueryServerTest, MissingSub_Unauthenticated) {
-  auto tok = MakeBearerToken(kTestSigningKey, TokenKind::kMissingSub);
+// No Scopes claim → UNAUTHENTICATED.
+TEST_F(DirectQueryServerTest, MissingScope_Unauthenticated) {
+  auto tok = MakeBearerToken(kTestSigningKey, TokenKind::kMissingScope);
   EXPECT_EQ(::grpc::StatusCode::UNAUTHENTICATED, CallExecuteScript(tok).error_code());
 }
 

--- a/src/vizier/services/agent/pem/direct_query_server_test.cc
+++ b/src/vizier/services/agent/pem/direct_query_server_test.cc
@@ -56,12 +56,8 @@ constexpr char kTestSigningKey[] = "test-signing-key-do-not-use-in-prod";
 constexpr char kWrongSigningKey[] = "a-different-key";
 
 // TokenKind drives MakeBearerToken's claim shape. The verifier
-// (direct_query_server.cc:verifyHs256Jwt) checks: HS256 alg, signature, aud
-// (string or array containing "vizier"), exp (numeric, > now). So the kind
-// names below reflect what the verifier actually inspects — there are
-// deliberately no "kWrongIss" / "kWrongSub" / "kFutureNbf" variants because
-// the verifier ignores those claims; minting them differently doesn't
-// change auth outcomes and would produce misleading test names.
+// (direct_query_server.cc:verifyHs256Jwt) checks: HS256 alg, signature, iss=PL,
+// sub=service, aud (string or array containing "vizier"), exp (numeric, > now).
 enum class TokenKind {
   kValid,        // signed with `signing_key`, exp +60s, aud=["vizier"]
   kWrongKey,     // signed with caller's signing_key; caller passes the wrong key to MakeBearerToken
@@ -71,6 +67,10 @@ enum class TokenKind {
   kWrongAud,     // signed correctly, aud=["wrong-service"]
   kMissingExp,   // signed correctly, no exp claim (verifier requires exp)
   kAlgNone,      // alg=none header forgery (verifier must reject — refuses anything but HS256)
+  kWrongIss,     // signed correctly, iss="not-PL"
+  kMissingIss,   // signed correctly, no iss claim
+  kWrongSub,     // signed correctly, sub="user"
+  kMissingSub,   // signed correctly, no sub claim
 };
 
 // MakeBearerToken mints a JWT for the in-process call's `authorization` metadata,
@@ -105,7 +105,15 @@ std::string MakeBearerToken(const std::string& signing_key, TokenKind kind) {
   }
 
   jwt::jwt_object obj{jwt::params::algorithm("HS256")};
-  obj.add_claim("iss", "PL");
+  switch (kind) {
+    case TokenKind::kWrongIss:
+      obj.add_claim("iss", "not-PL");
+      break;
+    case TokenKind::kMissingIss:
+      break;
+    default:
+      obj.add_claim("iss", "PL");
+  }
   // RFC 7519 §4.1.3 + pixie's go mint convention (jwt.go:46
   // Audience([]string{...})) serialize aud as a JSON array. The verifier
   // (direct_query_server.cc) accepts both string and array forms.
@@ -128,7 +136,15 @@ std::string MakeBearerToken(const std::string& signing_key, TokenKind kind) {
   if (kind != TokenKind::kMissingExp) {
     obj.add_claim("exp", now + exp_offset);
   }
-  obj.add_claim("sub", "service");
+  switch (kind) {
+    case TokenKind::kWrongSub:
+      obj.add_claim("sub", "user");
+      break;
+    case TokenKind::kMissingSub:
+      break;
+    default:
+      obj.add_claim("sub", "service");
+  }
   obj.add_claim("Scopes", "service");
   obj.add_claim("ServiceID", "dx-test");
   obj.secret(signing_key);
@@ -251,6 +267,34 @@ TEST_F(DirectQueryServerTest, WrongAud_Unauthenticated) {
 // §4.1.3 doesn't mandate it, but our security model does).
 TEST_F(DirectQueryServerTest, MissingAud_Unauthenticated) {
   auto tok = MakeBearerToken(kTestSigningKey, TokenKind::kMissingAud);
+  EXPECT_EQ(::grpc::StatusCode::UNAUTHENTICATED, CallExecuteScript(tok).error_code());
+}
+
+// Wrong iss → UNAUTHENTICATED. The mint side (manager.cc::GenerateServiceToken)
+// always emits iss="PL"; rejecting other issuers stops cross-aud-class tokens
+// signed with the same key (e.g., a token an external system minted with
+// aud=vizier but iss=something-else) from authenticating here.
+TEST_F(DirectQueryServerTest, WrongIss_Unauthenticated) {
+  auto tok = MakeBearerToken(kTestSigningKey, TokenKind::kWrongIss);
+  EXPECT_EQ(::grpc::StatusCode::UNAUTHENTICATED, CallExecuteScript(tok).error_code());
+}
+
+// No iss claim → UNAUTHENTICATED.
+TEST_F(DirectQueryServerTest, MissingIss_Unauthenticated) {
+  auto tok = MakeBearerToken(kTestSigningKey, TokenKind::kMissingIss);
+  EXPECT_EQ(::grpc::StatusCode::UNAUTHENTICATED, CallExecuteScript(tok).error_code());
+}
+
+// Wrong sub → UNAUTHENTICATED. The mint side emits sub="service"; user-scoped
+// tokens (sub="user") must not authenticate against this service-only endpoint.
+TEST_F(DirectQueryServerTest, WrongSub_Unauthenticated) {
+  auto tok = MakeBearerToken(kTestSigningKey, TokenKind::kWrongSub);
+  EXPECT_EQ(::grpc::StatusCode::UNAUTHENTICATED, CallExecuteScript(tok).error_code());
+}
+
+// No sub claim → UNAUTHENTICATED.
+TEST_F(DirectQueryServerTest, MissingSub_Unauthenticated) {
+  auto tok = MakeBearerToken(kTestSigningKey, TokenKind::kMissingSub);
   EXPECT_EQ(::grpc::StatusCode::UNAUTHENTICATED, CallExecuteScript(tok).error_code());
 }
 

--- a/src/vizier/services/agent/pem/direct_query_server_test.cc
+++ b/src/vizier/services/agent/pem/direct_query_server_test.cc
@@ -81,11 +81,11 @@ std::string MakeBearerToken(const std::string& signing_key, TokenKind kind) {
 class DirectQueryServerTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    // carnot/engine null for the auth + scope-guard cases (no execution reached).
-    // TODO(pem-agent): for QueryStreamsRows, build a Carnot fixture with a seeded
-    // table (see src/carnot/carnot_test.cc) and pass it here.
+    // carnot/engine/result_server null for the auth + scope-guard cases (no
+    // execution reached). Step 2: ValidToken_TrivialQuery_StreamsRows builds a
+    // real CarnotTest-style fixture in its own SetUp override.
     service_ = std::make_unique<DirectQueryServer>(/*carnot*/ nullptr, /*engine_state*/ nullptr,
-                                                   kTestSigningKey);
+                                                   /*result_server*/ nullptr, kTestSigningKey);
     ::grpc::ServerBuilder builder;
     builder.RegisterService(service_.get());
     server_ = builder.BuildAndStart();

--- a/src/vizier/services/agent/pem/direct_query_server_test.cc
+++ b/src/vizier/services/agent/pem/direct_query_server_test.cc
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// TDD contract for the PEM direct-query endpoint (entlein/dx#29).
+//
+// Authored by dx-agent as the executable spec; the pem-agent makes it pass.
+// These are the acceptance criteria from DIRECT_QUERY_CONTRACT.md. The stub in
+// direct_query_server.cc fails closed (UNAUTHENTICATED / UNIMPLEMENTED), so the
+// auth-negative cases pass today and the positive/execution cases are the red work.
+//
+// The fixture runs an in-process gRPC server hosting DirectQueryServer and a real
+// client stub, so authorization metadata flows exactly as in production.
+
+#include <grpcpp/grpcpp.h>
+#include <grpcpp/security/server_credentials.h>
+#include <memory>
+#include <string>
+
+#include "src/common/testing/testing.h"
+#include "src/api/proto/vizierpb/vizierapi.grpc.pb.h"
+#include "src/vizier/services/agent/pem/direct_query_server.h"
+
+namespace px {
+namespace vizier {
+namespace agent {
+
+constexpr char kTestSigningKey[] = "test-signing-key-do-not-use-in-prod";
+constexpr char kWrongSigningKey[] = "a-different-key";
+
+enum class TokenKind { kValid, kWrongKey, kExpired };
+
+// MakeBearerToken returns a JWT for the in-process call's `authorization` metadata.
+// TODO(pem-agent): implement to match the C++ verifier in AuthenticateRequest —
+// kValid: HS256 over `signing_key`, unexpired, vizier audience (mirror the Go
+// GenerateJWTForService("dx","vizier") claims in src/shared/services/utils);
+// kWrongKey: signed with a different key; kExpired: valid signature but exp in the
+// past. The token-maker and the verifier are a matched pair you own.
+//
+// Placeholder body so the test BUILDS + LINKS today: it returns a non-empty
+// non-JWT string, which the fail-closed stub verifier rejects → the auth-negative
+// cases pass for the right reason, and ValidToken_* stays red until you implement
+// both this maker and AuthenticateRequest.
+std::string MakeBearerToken(const std::string& signing_key, TokenKind kind) {
+  (void)signing_key;
+  switch (kind) {
+    case TokenKind::kValid:
+      return "PLACEHOLDER.valid.token";  // TODO(pem-agent): real signed JWT
+    case TokenKind::kWrongKey:
+      return "PLACEHOLDER.wrongkey.token";
+    case TokenKind::kExpired:
+      return "PLACEHOLDER.expired.token";
+  }
+  return "";
+}
+
+// Test fixture: in-process server hosting DirectQueryServer + a client stub.
+class DirectQueryServerTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    // carnot/engine null for the auth + scope-guard cases (no execution reached).
+    // TODO(pem-agent): for QueryStreamsRows, build a Carnot fixture with a seeded
+    // table (see src/carnot/carnot_test.cc) and pass it here.
+    service_ = std::make_unique<DirectQueryServer>(/*carnot*/ nullptr, /*engine_state*/ nullptr,
+                                                   kTestSigningKey);
+    ::grpc::ServerBuilder builder;
+    builder.RegisterService(service_.get());
+    server_ = builder.BuildAndStart();
+    stub_ = ::px::api::vizierpb::VizierService::NewStub(server_->InProcessChannel({}));
+  }
+  void TearDown() override {
+    if (server_) server_->Shutdown();
+  }
+
+  // Calls ExecuteScript with the given bearer token (empty = no auth header) and a
+  // trivial query, draining the stream. Returns the final gRPC status.
+  ::grpc::Status CallExecuteScript(const std::string& bearer, bool mutation = false) {
+    ::grpc::ClientContext ctx;
+    if (!bearer.empty()) ctx.AddMetadata("authorization", "Bearer " + bearer);
+    ::px::api::vizierpb::ExecuteScriptRequest req;
+    req.set_query_str("import px\npx.display(px.DataFrame('http_events'))");
+    req.set_mutation(mutation);
+    auto reader = stub_->ExecuteScript(&ctx, req);
+    ::px::api::vizierpb::ExecuteScriptResponse resp;
+    while (reader->Read(&resp)) { /* drain */
+    }
+    return reader->Finish();
+  }
+
+  std::unique_ptr<DirectQueryServer> service_;
+  std::unique_ptr<::grpc::Server> server_;
+  std::unique_ptr<::px::api::vizierpb::VizierService::Stub> stub_;
+};
+
+// 3a. No token → UNAUTHENTICATED (passes against the fail-closed stub today).
+TEST_F(DirectQueryServerTest, NoToken_Unauthenticated) {
+  EXPECT_EQ(::grpc::StatusCode::UNAUTHENTICATED, CallExecuteScript("").error_code());
+}
+
+// 3b. Token signed with the wrong key → UNAUTHENTICATED.
+TEST_F(DirectQueryServerTest, WrongKey_Unauthenticated) {
+  auto tok = MakeBearerToken(kWrongSigningKey, TokenKind::kWrongKey);
+  EXPECT_EQ(::grpc::StatusCode::UNAUTHENTICATED, CallExecuteScript(tok).error_code());
+}
+
+// 3c. Expired token → UNAUTHENTICATED.
+TEST_F(DirectQueryServerTest, ExpiredToken_Unauthenticated) {
+  auto tok = MakeBearerToken(kTestSigningKey, TokenKind::kExpired);
+  EXPECT_EQ(::grpc::StatusCode::UNAUTHENTICATED, CallExecuteScript(tok).error_code());
+}
+
+// 5. Mutations are out of scope → UNIMPLEMENTED (and proves a valid token authenticates).
+TEST_F(DirectQueryServerTest, ValidToken_Mutation_Unimplemented) {
+  auto tok = MakeBearerToken(kTestSigningKey, TokenKind::kValid);
+  EXPECT_EQ(::grpc::StatusCode::UNIMPLEMENTED, CallExecuteScript(tok, /*mutation*/ true).error_code());
+}
+
+// 2. Valid token + trivial query → OK stream. Needs a Carnot fixture with a seeded
+// table; until SetUp() supplies one, this is the core red→green for the pem-agent.
+TEST_F(DirectQueryServerTest, ValidToken_TrivialQuery_StreamsRows) {
+  GTEST_SKIP() << "TODO(pem-agent): seed a Carnot fixture in SetUp(), then assert "
+                  "ExecuteScript returns OK and streams >=1 ExecuteScriptResponse.";
+  // auto tok = MakeBearerToken(kTestSigningKey, TokenKind::kValid);
+  // EXPECT_EQ(::grpc::StatusCode::OK, CallExecuteScript(tok).error_code());
+}
+
+// 4. Metadata-connected per-pod filter returns only that pod's rows (closes #15 on
+// the real PEM). Integration-style; needs metadata + a multi-pod fixture.
+TEST_F(DirectQueryServerTest, PerPodFilter_MetadataConnected) {
+  GTEST_SKIP() << "TODO(pem-agent): with metadata wired, a per-pod-filtered PxL must "
+                  "return only the target pod's rows (the gap standalone_pem could not close).";
+}
+
+}  // namespace agent
+}  // namespace vizier
+}  // namespace px

--- a/src/vizier/services/agent/pem/direct_query_server_test.cc
+++ b/src/vizier/services/agent/pem/direct_query_server_test.cc
@@ -31,8 +31,8 @@
 #include <memory>
 #include <string>
 
-#include "src/common/testing/testing.h"
 #include "src/api/proto/vizierpb/vizierapi.grpc.pb.h"
+#include "src/common/testing/testing.h"
 #include "src/vizier/services/agent/pem/direct_query_server.h"
 
 namespace px {
@@ -126,7 +126,8 @@ TEST_F(DirectQueryServerTest, ExpiredToken_Unauthenticated) {
 // 5. Mutations are out of scope → UNIMPLEMENTED (and proves a valid token authenticates).
 TEST_F(DirectQueryServerTest, ValidToken_Mutation_Unimplemented) {
   auto tok = MakeBearerToken(kTestSigningKey, TokenKind::kValid);
-  EXPECT_EQ(::grpc::StatusCode::UNIMPLEMENTED, CallExecuteScript(tok, /*mutation*/ true).error_code());
+  EXPECT_EQ(::grpc::StatusCode::UNIMPLEMENTED,
+            CallExecuteScript(tok, /*mutation*/ true).error_code());
 }
 
 // 2. Valid token + trivial query → OK stream. Needs a Carnot fixture with a seeded

--- a/src/vizier/services/agent/pem/direct_query_server_test.cc
+++ b/src/vizier/services/agent/pem/direct_query_server_test.cc
@@ -26,9 +26,12 @@
 // The fixture runs an in-process gRPC server hosting DirectQueryServer and a real
 // client stub, so authorization metadata flows exactly as in production.
 
+#include <atomic>
 #include <chrono>
+#include <future>
 #include <memory>
 #include <string>
+#include <thread>
 #include <vector>  // std::vector for the aud-array mint
 
 #include <grpcpp/grpcpp.h>
@@ -52,7 +55,23 @@ namespace agent {
 constexpr char kTestSigningKey[] = "test-signing-key-do-not-use-in-prod";
 constexpr char kWrongSigningKey[] = "a-different-key";
 
-enum class TokenKind { kValid, kWrongKey, kExpired };
+// TokenKind drives MakeBearerToken's claim shape. The verifier
+// (direct_query_server.cc:verifyHs256Jwt) checks: HS256 alg, signature, aud
+// (string or array containing "vizier"), exp (numeric, > now). So the kind
+// names below reflect what the verifier actually inspects — there are
+// deliberately no "kWrongIss" / "kWrongSub" / "kFutureNbf" variants because
+// the verifier ignores those claims; minting them differently doesn't
+// change auth outcomes and would produce misleading test names.
+enum class TokenKind {
+  kValid,           // signed with `signing_key`, exp +60s, aud=["vizier"]
+  kWrongKey,        // signed with caller's signing_key; caller passes the wrong key to MakeBearerToken
+  kExpired,         // signed correctly, exp -60s
+  kAudAsString,     // signed correctly, aud="vizier" (string, not array — backwards compat path)
+  kMissingAud,      // signed correctly, no aud claim
+  kWrongAud,        // signed correctly, aud=["wrong-service"]
+  kMissingExp,      // signed correctly, no exp claim (verifier requires exp)
+  kAlgNone,         // alg=none header forgery (verifier must reject — refuses anything but HS256)
+};
 
 // MakeBearerToken mints a JWT for the in-process call's `authorization` metadata,
 // matching the verifier in AuthenticateRequest. Claim shape mirrors
@@ -70,19 +89,45 @@ std::string MakeBearerToken(const std::string& signing_key, TokenKind kind) {
   auto now = system_clock::now();
   auto exp_offset = (kind == TokenKind::kExpired) ? seconds{-60} : seconds{60};
 
+  // kAlgNone takes a separate codepath: cpp_jwt doesn't expose `alg:"none"`
+  // (which is correct — RFC 8725 banned it), so we hand-craft the forgery
+  // with an empty signature segment. The verifier must reject this before
+  // touching the claims.
+  if (kind == TokenKind::kAlgNone) {
+    // Header: {"alg":"none","typ":"JWT"} → base64url, no padding.
+    constexpr char kHeader[] = "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0";
+    // Payload: a perfectly fine set of claims so the test isolates the alg
+    // rejection — base64url of {"aud":["vizier"],"exp":4102444800} (well in
+    // the future). The trailing signature segment is empty (".") to mirror
+    // the canonical "alg:none" forgery shape.
+    constexpr char kPayload[] = "eyJhdWQiOlsidml6aWVyIl0sImV4cCI6NDEwMjQ0NDgwMH0";
+    return std::string(kHeader) + "." + kPayload + ".";
+  }
+
   jwt::jwt_object obj{jwt::params::algorithm("HS256")};
   obj.add_claim("iss", "PL");
   // RFC 7519 §4.1.3 + pixie's go mint convention (jwt.go:46
   // Audience([]string{...})) serialize aud as a JSON array. The verifier
-  // (direct_query_server.cc) accepts both string and array forms, but the
-  // unit test mints the ARRAY form so it guards against a regression to
-  // string-only verification — dx-agent reports the live e2e would
-  // UNAUTHENTICATED if we drifted back.
-  obj.add_claim("aud", std::vector<std::string>{"vizier"});
+  // (direct_query_server.cc) accepts both string and array forms.
+  switch (kind) {
+    case TokenKind::kAudAsString:
+      obj.add_claim("aud", std::string("vizier"));
+      break;
+    case TokenKind::kWrongAud:
+      obj.add_claim("aud", std::vector<std::string>{"wrong-service"});
+      break;
+    case TokenKind::kMissingAud:
+      // Intentionally omit aud entirely.
+      break;
+    default:
+      obj.add_claim("aud", std::vector<std::string>{"vizier"});
+  }
   obj.add_claim("jti", "direct-query-test");
   obj.add_claim("iat", now);
   obj.add_claim("nbf", now - seconds{60});
-  obj.add_claim("exp", now + exp_offset);
+  if (kind != TokenKind::kMissingExp) {
+    obj.add_claim("exp", now + exp_offset);
+  }
   obj.add_claim("sub", "service");
   obj.add_claim("Scopes", "service");
   obj.add_claim("ServiceID", "dx-test");
@@ -111,10 +156,19 @@ class DirectQueryServerTest : public ::testing::Test {
   // Calls ExecuteScript with the given bearer token (empty = no auth header) and a
   // trivial query, draining the stream. Returns the final gRPC status.
   ::grpc::Status CallExecuteScript(const std::string& bearer, bool mutation = false) {
+    return CallExecuteScriptRaw(/*authz_value=*/bearer.empty() ? "" : "Bearer " + bearer,
+                                "import px\npx.display(px.DataFrame('http_events'))", mutation);
+  }
+
+  // CallExecuteScriptRaw lets robustness tests craft the raw `authorization`
+  // metadata value (e.g. "Bearer", "bearer <tok>", "Token …") and the PxL
+  // body. Pass an empty `authz_value` to send no auth header at all.
+  ::grpc::Status CallExecuteScriptRaw(const std::string& authz_value, const std::string& pxl,
+                                      bool mutation = false) {
     ::grpc::ClientContext ctx;
-    if (!bearer.empty()) ctx.AddMetadata("authorization", "Bearer " + bearer);
+    if (!authz_value.empty()) ctx.AddMetadata("authorization", authz_value);
     ::px::api::vizierpb::ExecuteScriptRequest req;
-    req.set_query_str("import px\npx.display(px.DataFrame('http_events'))");
+    req.set_query_str(pxl);
     req.set_mutation(mutation);
     auto reader = stub_->ExecuteScript(&ctx, req);
     ::px::api::vizierpb::ExecuteScriptResponse resp;
@@ -152,6 +206,210 @@ TEST_F(DirectQueryServerTest, ValidToken_Mutation_Unimplemented) {
             CallExecuteScript(tok, /*mutation*/ true).error_code());
 }
 
+// ===========================================================================
+// JWT robustness — claim shape / format / algorithm. The verifier
+// (direct_query_server.cc::verifyHs256Jwt) inspects: HS256 alg, signature,
+// aud (string or array containing "vizier"), exp (numeric, > now).
+// ===========================================================================
+
+// Wire-format malformed: a non-JWT string can't be split into 3 base64url parts.
+TEST_F(DirectQueryServerTest, GarbageBearer_Unauthenticated) {
+  // Looks like a token (long random string) but doesn't have the three-dot
+  // structure → verifier rejects at the absl::StrSplit('.') step.
+  EXPECT_EQ(::grpc::StatusCode::UNAUTHENTICATED,
+            CallExecuteScript("not.a.real.jwt.token").error_code());
+}
+
+// alg:none header is RFC 8725's canonical forgery — the verifier must refuse
+// anything but HS256 even when the rest of the token is well-formed.
+TEST_F(DirectQueryServerTest, AlgNoneToken_Unauthenticated) {
+  auto tok = MakeBearerToken(kTestSigningKey, TokenKind::kAlgNone);
+  EXPECT_EQ(::grpc::StatusCode::UNAUTHENTICATED, CallExecuteScript(tok).error_code());
+}
+
+// aud as a single string instead of an array — pixie's Go mint uses the array
+// form, but kelvin/query-broker (and we) accept either per RFC 7519 §4.1.3.
+TEST_F(DirectQueryServerTest, ValidToken_AudAsString_Authenticated) {
+  // We hit the auth+scope guard, not Carnot exec, so this fixture's
+  // null-carnot OK signal is UNIMPLEMENTED for a non-mutation query (the
+  // CarnotTest fixture below proves the exec path for the array form).
+  // Auth must pass for the string-aud form to reach the scope-guard.
+  auto tok = MakeBearerToken(kTestSigningKey, TokenKind::kAudAsString);
+  auto status = CallExecuteScript(tok).error_code();
+  EXPECT_NE(::grpc::StatusCode::UNAUTHENTICATED, status)
+      << "aud-as-string must still authenticate (backwards-compat with non-array aud).";
+}
+
+// Wrong aud → UNAUTHENTICATED. Guards against a regression where the verifier
+// silently accepted any aud value.
+TEST_F(DirectQueryServerTest, WrongAud_Unauthenticated) {
+  auto tok = MakeBearerToken(kTestSigningKey, TokenKind::kWrongAud);
+  EXPECT_EQ(::grpc::StatusCode::UNAUTHENTICATED, CallExecuteScript(tok).error_code());
+}
+
+// No aud claim → UNAUTHENTICATED. The verifier requires the claim (RFC 7519
+// §4.1.3 doesn't mandate it, but our security model does).
+TEST_F(DirectQueryServerTest, MissingAud_Unauthenticated) {
+  auto tok = MakeBearerToken(kTestSigningKey, TokenKind::kMissingAud);
+  EXPECT_EQ(::grpc::StatusCode::UNAUTHENTICATED, CallExecuteScript(tok).error_code());
+}
+
+// No exp claim → UNAUTHENTICATED. Prevents non-expiring tokens, which would
+// turn any leaked token into a permanent bearer credential.
+TEST_F(DirectQueryServerTest, MissingExp_Unauthenticated) {
+  auto tok = MakeBearerToken(kTestSigningKey, TokenKind::kMissingExp);
+  EXPECT_EQ(::grpc::StatusCode::UNAUTHENTICATED, CallExecuteScript(tok).error_code());
+}
+
+// ===========================================================================
+// Authorization header parsing — Bearer scheme handling.
+// ===========================================================================
+
+// Bearer prefix but no token after the space → UNAUTHENTICATED. Matches the
+// stripBearerPrefix → token.empty() check.
+TEST_F(DirectQueryServerTest, BearerEmptyToken_Unauthenticated) {
+  EXPECT_EQ(::grpc::StatusCode::UNAUTHENTICATED,
+            CallExecuteScriptRaw("Bearer ", "import px\npx.display(px.DataFrame('http_events'))")
+                .error_code());
+}
+
+// Lowercase "bearer " prefix → must still authenticate (gRPC metadata
+// normalisation typically lowercases keys but not values; the verifier
+// explicitly lowercase-compares the scheme to be defensive).
+TEST_F(DirectQueryServerTest, ValidToken_LowercaseBearerPrefix_Authenticated) {
+  auto tok = MakeBearerToken(kTestSigningKey, TokenKind::kValid);
+  auto status = CallExecuteScriptRaw("bearer " + tok,
+                                     "import px\npx.display(px.DataFrame('http_events'))")
+                    .error_code();
+  EXPECT_NE(::grpc::StatusCode::UNAUTHENTICATED, status)
+      << "case-insensitive Bearer scheme must authenticate (e.g. 'bearer <tok>').";
+}
+
+// Wrong scheme ("Token <jwt>") → UNAUTHENTICATED. The verifier only accepts
+// the Bearer scheme.
+TEST_F(DirectQueryServerTest, WrongAuthScheme_Unauthenticated) {
+  auto tok = MakeBearerToken(kTestSigningKey, TokenKind::kValid);
+  EXPECT_EQ(::grpc::StatusCode::UNAUTHENTICATED,
+            CallExecuteScriptRaw("Token " + tok,
+                                 "import px\npx.display(px.DataFrame('http_events'))")
+                .error_code());
+}
+
+// ===========================================================================
+// Tampering tests — bit-level token manipulation. Each scenario flips a
+// specific portion of an otherwise-valid token and asserts UNAUTHENTICATED.
+// These lock down the verifier against the canonical JWT attack catalogue
+// (RFC 8725, OWASP JWT cheat sheet). The named scenarios are documented in
+// DIRECT_QUERY_SECURITY.md "Tampering scenarios — unit-test coverage".
+// ===========================================================================
+
+namespace {
+
+// FlipNthChar returns a copy of `s` with character at index `idx` rotated:
+// alphanumerics shift by 1, others become 'X'. Cheap deterministic mutation
+// that preserves length so b64-segment boundaries don't realign by accident.
+std::string FlipNthChar(const std::string& s, size_t idx) {
+  auto out = s;
+  if (idx >= out.size()) return out;
+  char c = out[idx];
+  if (c >= 'A' && c < 'Z') {
+    out[idx] = c + 1;
+  } else if (c >= 'a' && c < 'z') {
+    out[idx] = c + 1;
+  } else if (c >= '0' && c < '9') {
+    out[idx] = c + 1;
+  } else {
+    out[idx] = 'X';
+  }
+  return out;
+}
+
+// SegmentIndex returns the (start, end) range of the Nth dot-separated
+// segment in s. Used to target the header / payload / signature surgically.
+std::pair<size_t, size_t> SegmentIndex(const std::string& s, int n) {
+  size_t start = 0;
+  for (int i = 0; i < n; ++i) {
+    auto dot = s.find('.', start);
+    if (dot == std::string::npos) return {std::string::npos, std::string::npos};
+    start = dot + 1;
+  }
+  auto end = s.find('.', start);
+  if (end == std::string::npos) end = s.size();
+  return {start, end};
+}
+
+}  // namespace
+
+// Flip a single byte in the signature segment → HMAC mismatch.
+TEST_F(DirectQueryServerTest, TamperedSignatureByte_Unauthenticated) {
+  auto tok = MakeBearerToken(kTestSigningKey, TokenKind::kValid);
+  auto [start, end] = SegmentIndex(tok, 2);
+  ASSERT_NE(std::string::npos, start);
+  // Use the middle of the signature so we don't accidentally hit the padding
+  // boundary (cpp_jwt's emit doesn't pad b64url, but defensive anyway).
+  auto tampered = FlipNthChar(tok, start + (end - start) / 2);
+  EXPECT_EQ(::grpc::StatusCode::UNAUTHENTICATED, CallExecuteScript(tampered).error_code());
+}
+
+// Flip a single byte in the payload segment → signing-input differs from
+// what the supplied signature was over → HMAC mismatch.
+TEST_F(DirectQueryServerTest, TamperedPayloadByte_Unauthenticated) {
+  auto tok = MakeBearerToken(kTestSigningKey, TokenKind::kValid);
+  auto [start, end] = SegmentIndex(tok, 1);
+  ASSERT_NE(std::string::npos, start);
+  auto tampered = FlipNthChar(tok, start + 5);  // first b64 char that maps to non-padding
+  EXPECT_EQ(::grpc::StatusCode::UNAUTHENTICATED, CallExecuteScript(tampered).error_code());
+}
+
+// Flip a byte in the header segment → either alg-check fails or signature
+// mismatches. Either way, UNAUTHENTICATED.
+TEST_F(DirectQueryServerTest, TamperedHeaderByte_Unauthenticated) {
+  auto tok = MakeBearerToken(kTestSigningKey, TokenKind::kValid);
+  auto [start, end] = SegmentIndex(tok, 0);
+  ASSERT_NE(std::string::npos, start);
+  auto tampered = FlipNthChar(tok, start + 5);
+  EXPECT_EQ(::grpc::StatusCode::UNAUTHENTICATED, CallExecuteScript(tampered).error_code());
+}
+
+// Truncate the last 10 chars → signature too short to base64-decode cleanly
+// OR decodes to a byte string that doesn't match the HMAC.
+TEST_F(DirectQueryServerTest, TruncatedToken_Unauthenticated) {
+  auto tok = MakeBearerToken(kTestSigningKey, TokenKind::kValid);
+  ASSERT_GT(tok.size(), 20u);
+  auto truncated = tok.substr(0, tok.size() - 10);
+  EXPECT_EQ(::grpc::StatusCode::UNAUTHENTICATED, CallExecuteScript(truncated).error_code());
+}
+
+// Concatenate two valid tokens with a dot — produces a 5-segment string. The
+// 3-part split check fails immediately ("malformed JWT").
+TEST_F(DirectQueryServerTest, ConcatenatedTokens_Unauthenticated) {
+  auto tok1 = MakeBearerToken(kTestSigningKey, TokenKind::kValid);
+  auto tok2 = MakeBearerToken(kTestSigningKey, TokenKind::kValid);
+  auto concatenated = tok1 + "." + tok2;
+  EXPECT_EQ(::grpc::StatusCode::UNAUTHENTICATED, CallExecuteScript(concatenated).error_code());
+}
+
+// Algorithm confusion: header advertises HS384, signature is HS256. The
+// verifier requires alg == "HS256" exactly, so HS384 alone fails — but this
+// is the explicit "alg substitution" attack from RFC 8725 §2.6 (the more
+// classic variant uses RS256 / public-key confusion; we don't sign with
+// asymmetric keys so the HMAC-flavoured variant is what we guard against).
+TEST_F(DirectQueryServerTest, AlgConfusion_HS384_Unauthenticated) {
+  // Header: {"alg":"HS384","typ":"JWT"} → base64url, no padding.
+  constexpr char kHS384Header[] = "eyJhbGciOiJIUzM4NCIsInR5cCI6IkpXVCJ9";
+  // Use a valid HS256 token's payload + signature so the only difference
+  // from a normal token is the header's alg value.
+  auto tok = MakeBearerToken(kTestSigningKey, TokenKind::kValid);
+  auto [p_start, p_end] = SegmentIndex(tok, 1);
+  auto [s_start, s_end] = SegmentIndex(tok, 2);
+  ASSERT_NE(std::string::npos, p_start);
+  ASSERT_NE(std::string::npos, s_start);
+  auto payload = tok.substr(p_start, p_end - p_start);
+  auto signature = tok.substr(s_start, s_end - s_start);
+  auto confused = std::string(kHS384Header) + "." + payload + "." + signature;
+  EXPECT_EQ(::grpc::StatusCode::UNAUTHENTICATED, CallExecuteScript(confused).error_code());
+}
+
 // 2. Valid token + trivial query → OK stream. The fixture below builds a
 // real CarnotTest-style table_store + Carnot + LocalGRPCResultSinkServer, then
 // passes them to DirectQueryServer, so ExecuteScript actually compiles and
@@ -179,7 +437,12 @@ class DirectQueryServerExecTest : public ::testing::Test {
     carnot_ = ::px::carnot::Carnot::Create(sole::uuid4(), std::move(func_registry), table_store_,
                                            std::move(clients_config), std::move(server_config))
                   .ConsumeValueOrDie();
+    // Two tables → exercises multi-table queries (px.display(t1) +
+    // px.display(t2) in one PxL emits two result streams). Mirrors the
+    // shape dx pemdirect actually queries (http_events + dns_events at
+    // minimum; conn_stats added when #5's column shape lands here too).
     table_store_->AddTable("http_events", MakeHTTPEventsTable());
+    table_store_->AddTable("dns_events", MakeDNSEventsTable());
 
     service_ = std::make_unique<DirectQueryServer>(carnot_.get(), carnot_->GetEngineState(),
                                                    result_server_.get(), kTestSigningKey);
@@ -208,6 +471,46 @@ class DirectQueryServerExecTest : public ::testing::Test {
         },
         {"time_", "upid", "remote_addr", "remote_port", "trace_role"});
     return ::px::table_store::Table::Create("http_events", rel);
+  }
+
+  // dns_events — matches the routine query path the dx pemdirect uses to
+  // cross-check DNS lookups against http_events in the log4shell chain.
+  // Same UTC time/upid skeleton + a couple of DNS-specific columns; rows
+  // empty (schema-only query in tests).
+  std::shared_ptr<::px::table_store::Table> MakeDNSEventsTable() {
+    ::px::table_store::schema::Relation rel(
+        {
+            ::px::types::DataType::TIME64NS,
+            ::px::types::DataType::UINT128,
+            ::px::types::DataType::STRING,
+            ::px::types::DataType::INT64,
+            ::px::types::DataType::STRING,
+        },
+        {"time_", "upid", "remote_addr", "remote_port", "req_header"});
+    return ::px::table_store::Table::Create("dns_events", rel);
+  }
+
+  // Helper for the new tests below — sends a PxL with a valid bearer and
+  // returns (final-status, response-count).
+  struct StreamOutcome {
+    ::grpc::Status status;
+    int response_count = 0;
+  };
+  StreamOutcome RunPxL(const std::string& pxl) {
+    auto tok = MakeBearerToken(kTestSigningKey, TokenKind::kValid);
+    ::grpc::ClientContext ctx;
+    ctx.AddMetadata("authorization", "Bearer " + tok);
+    ::px::api::vizierpb::ExecuteScriptRequest req;
+    req.set_query_str(pxl);
+    req.set_mutation(false);
+    auto reader = stub_->ExecuteScript(&ctx, req);
+    StreamOutcome out;
+    ::px::api::vizierpb::ExecuteScriptResponse resp;
+    while (reader->Read(&resp)) {
+      ++out.response_count;
+    }
+    out.status = reader->Finish();
+    return out;
   }
 
   std::shared_ptr<::px::table_store::TableStore> table_store_;
@@ -241,6 +544,221 @@ TEST_F(DirectQueryServerExecTest, ValidToken_TrivialQuery_StreamsRows) {
 TEST_F(DirectQueryServerTest, PerPodFilter_MetadataConnected) {
   GTEST_SKIP() << "TODO(pem-agent): with metadata wired, a per-pod-filtered PxL must "
                   "return only the target pod's rows (the gap standalone_pem could not close).";
+}
+
+// ===========================================================================
+// Routine query shapes — covers the PxL patterns dx pemdirect actually emits.
+// Each must complete OK and stream at least one response (schema-only is fine
+// against an empty-rows fixture; the goal is "the path doesn't drop frames").
+// ===========================================================================
+
+// Column-projection query — `df[['col1','col2']]` shape, the canonical PxL
+// way to ask for a subset.
+TEST_F(DirectQueryServerExecTest, ValidToken_ColumnProjection_StreamsRows) {
+  auto out = RunPxL(
+      "import px\n"
+      "df = px.DataFrame('http_events')\n"
+      "px.display(df[['remote_addr', 'remote_port']])\n");
+  EXPECT_EQ(::grpc::StatusCode::OK, out.status.error_code()) << out.status.error_message();
+  EXPECT_GE(out.response_count, 1);
+}
+
+// Multi-display query — two px.display() calls emit two result tables. dx
+// pemdirect uses this pattern to fan-out a single PxL into multiple
+// per-table streams (one ExecuteScript call, multiple QueryData.batch
+// arrivals). Validates the drain loop handles distinct table_ids.
+TEST_F(DirectQueryServerExecTest, ValidToken_MultiTableDisplay_StreamsRows) {
+  auto out = RunPxL(
+      "import px\n"
+      "px.display(px.DataFrame('http_events'), 'http_events')\n"
+      "px.display(px.DataFrame('dns_events'), 'dns_events')\n");
+  EXPECT_EQ(::grpc::StatusCode::OK, out.status.error_code()) << out.status.error_message();
+  // Two displays → expect ≥2 responses (each table produces at least meta_data
+  // + an EOS marker via the drain branch). The exact count depends on the
+  // sink's chunking; ≥2 is the minimum invariant.
+  EXPECT_GE(out.response_count, 2);
+}
+
+// Mutation flag with a valid token + a real Carnot → still UNIMPLEMENTED. The
+// mutation guard sits before the Carnot exec path; valid auth doesn't unlock
+// it. Pairs with the auth-only fixture's ValidToken_Mutation_Unimplemented.
+TEST_F(DirectQueryServerExecTest, ValidToken_Mutation_Unimplemented) {
+  auto tok = MakeBearerToken(kTestSigningKey, TokenKind::kValid);
+  ::grpc::ClientContext ctx;
+  ctx.AddMetadata("authorization", "Bearer " + tok);
+  ::px::api::vizierpb::ExecuteScriptRequest req;
+  req.set_query_str("import px\npx.display(px.DataFrame('http_events'))");
+  req.set_mutation(true);
+  auto reader = stub_->ExecuteScript(&ctx, req);
+  ::px::api::vizierpb::ExecuteScriptResponse resp;
+  while (reader->Read(&resp)) {
+  }
+  EXPECT_EQ(::grpc::StatusCode::UNIMPLEMENTED, reader->Finish().error_code());
+}
+
+// ===========================================================================
+// PxL robustness — malformed / nonsense queries should error cleanly, not
+// crash the server or hang the stream. dx-agent's pemdirect doesn't send
+// these in production, but defensive coverage means a typo or a bad script
+// upgrade can't take direct-query down.
+// ===========================================================================
+
+// Empty PxL → error (Carnot's compiler rejects empty input; expect a non-OK
+// stream finish, never OK with zero rows).
+TEST_F(DirectQueryServerExecTest, ValidToken_EmptyPxL_Errors) {
+  auto out = RunPxL("");
+  EXPECT_NE(::grpc::StatusCode::OK, out.status.error_code())
+      << "empty PxL must surface a compile error, not silently succeed.";
+}
+
+// Syntactically broken PxL — Carnot's compiler must report a clean error.
+TEST_F(DirectQueryServerExecTest, ValidToken_MalformedPxL_Errors) {
+  auto out = RunPxL("not valid python at all !!!");
+  EXPECT_NE(::grpc::StatusCode::OK, out.status.error_code());
+}
+
+// Query against a table that the fixture doesn't have → Carnot compile fails
+// with a clean error; no stream-hang, no crash.
+TEST_F(DirectQueryServerExecTest, ValidToken_NonexistentTable_Errors) {
+  auto out = RunPxL("import px\npx.display(px.DataFrame('this_table_does_not_exist'))");
+  EXPECT_NE(::grpc::StatusCode::OK, out.status.error_code())
+      << "Carnot must reject a query for an unregistered table at compile time.";
+}
+
+// ===========================================================================
+// Concurrency — N parallel ExecuteScript clients each get a clean stream.
+// The DirectQueryServer's per-call query_id (sole::uuid4) + the
+// LocalGRPCResultSinkServer's accumulator must not cross-contaminate state
+// between concurrent queries. dx daemon doesn't fan-out per-PEM (one query
+// at a time), but a future client could and we want to prove the path holds.
+// ===========================================================================
+
+TEST_F(DirectQueryServerExecTest, ValidToken_ConcurrentQueries_AllSucceed) {
+  constexpr int kN = 8;
+  std::vector<std::future<::grpc::Status>> futures;
+  futures.reserve(kN);
+  std::atomic<int> total_responses{0};
+  for (int i = 0; i < kN; ++i) {
+    futures.push_back(std::async(std::launch::async, [this, &total_responses]() {
+      auto tok = MakeBearerToken(kTestSigningKey, TokenKind::kValid);
+      ::grpc::ClientContext ctx;
+      ctx.AddMetadata("authorization", "Bearer " + tok);
+      ::px::api::vizierpb::ExecuteScriptRequest req;
+      req.set_query_str("import px\npx.display(px.DataFrame('http_events'))");
+      req.set_mutation(false);
+      auto reader = stub_->ExecuteScript(&ctx, req);
+      int n = 0;
+      ::px::api::vizierpb::ExecuteScriptResponse resp;
+      while (reader->Read(&resp)) {
+        ++n;
+      }
+      total_responses.fetch_add(n);
+      return reader->Finish();
+    }));
+  }
+  int ok_count = 0;
+  for (auto& f : futures) {
+    auto st = f.get();
+    if (st.ok()) ++ok_count;
+  }
+  EXPECT_EQ(kN, ok_count) << "all concurrent ExecuteScripts must finish OK";
+  EXPECT_GE(total_responses.load(), kN)
+      << "each successful stream contributes at least one response.";
+}
+
+// Sequential reuse of the same stub for multiple queries — validates the
+// service handles N back-to-back ExecuteScript calls on one channel cleanly
+// (no leaked sink state, no incrementing memory).
+TEST_F(DirectQueryServerExecTest, ValidToken_SequentialQueries_AllSucceed) {
+  constexpr int kN = 5;
+  for (int i = 0; i < kN; ++i) {
+    auto out = RunPxL("import px\npx.display(px.DataFrame('http_events'))");
+    EXPECT_EQ(::grpc::StatusCode::OK, out.status.error_code())
+        << "iteration " << i << ": " << out.status.error_message();
+    EXPECT_GE(out.response_count, 1) << "iteration " << i;
+  }
+}
+
+// ===========================================================================
+// Bidirectional fail-soft contract between direct-query (local) and the
+// broker path (vizier). The PEM exposes two query surfaces:
+//
+//   (a) broker — base Manager + main Carnot, NATS-connected; the
+//       production path the rest of the cloud query plane uses.
+//   (b) direct-query — DirectQueryServer + dedicated Carnot bound to a
+//       LocalGRPCResultSinkServer; the node-local path dx_daemon uses.
+//
+// The contract is symmetric: each side is OPTIONAL with respect to the
+// other. Failure of (a) must not take (b) down; failure of (b) must not
+// take (a) down.
+//
+// Direction (b) → (a) ("if local fails, broker keeps serving") is
+// implemented in pem_manager.cc:MaybeStartDirectQueryServer. Every error
+// path there returns Status::OK so PostRegisterHookImpl never propagates a
+// failure to the base manager's PX_CHECK_OK. The local code in this file
+// (DirectQueryServer) is also DECOUPLED from any broker / NATS dependency:
+// it accepts a Carnot, EngineState, and LocalGRPCResultSinkServer at
+// construction, and these tests build a self-contained fixture that
+// proves direct-query works without ever touching NATS. That's the
+// inversion of the contract: if you can build DirectQueryServer + drive
+// ExecuteScript end-to-end here, broker absence is provably not a
+// gating dependency for direct-query's own code path.
+//
+// Direction (a) → (b) ("if broker fails, direct-query keeps serving") is
+// NOT exercised end-to-end here because the surrounding PEMManager's
+// PostRegisterHookImpl is gated on broker registration completing. Surfacing
+// it requires either (i) hoisting MaybeStartDirectQueryServer earlier in
+// the lifecycle (out of scope for #29 — Stirling startup depends on the
+// PostRegister ordering) or (ii) introducing a "broker-optional" mode flag
+// in the shared Manager base. Tracked in DIRECT_QUERY_SECURITY.md and
+// DIRECT_QUERY_CONTRACT.md as a follow-up hardening.
+//
+// The contract is asserted in code below: the DirectQueryServerExecTest
+// fixture itself constructs DirectQueryServer with **no broker, no NATS,
+// no main Carnot, no shared manager state** and proves end-to-end PxL
+// streaming through ValidToken_TrivialQuery_StreamsRows and friends. If
+// any of those tests pass, direct-query is provably broker-independent
+// at the code-path level: a broker NATS / registration failure cannot
+// reach into the direct-query path.
+//
+// The two named tests below are documentary book-ends for that proof.
+
+// FailSoft_DirectQueryDecoupledFromBroker — documentary. The five-arg
+// constructor signature `DirectQueryServer(carnot, engine_state,
+// result_server, signing_key)` has no `nats_connector`, no
+// `mds_manager`, no `agent_info` — it cannot reach out to broker state.
+// The fixture's SetUp() never constructs a NATS connector or a base
+// Manager either. So if any *StreamsRows* test above is green, that's
+// the proof. This test exists so the contract is greppable from the
+// test source (search for FailSoft_DirectQueryDecoupledFromBroker) and
+// shows up as a named PASS in the CI report.
+TEST_F(DirectQueryServerExecTest, FailSoft_DirectQueryDecoupledFromBroker) {
+  ASSERT_NE(nullptr, service_.get()) << "fixture must build a service in isolation (no broker).";
+  // Re-run a trivial query → must succeed without any broker / NATS
+  // connection ever being established (the fixture didn't create one).
+  auto out = RunPxL("import px\npx.display(px.DataFrame('http_events'))");
+  EXPECT_EQ(::grpc::StatusCode::OK, out.status.error_code())
+      << "broker-free fixture must still serve direct-query: " << out.status.error_message();
+}
+
+// FailSoft_BrokerFailureToleratedByDirectQuery — RED placeholder. The
+// reverse direction (broker fails → direct-query keeps serving on the
+// live PEM) is NOT yet implemented end-to-end: pem_manager.cc's
+// MaybeStartDirectQueryServer runs from PostRegisterHookImpl which only
+// fires after broker NATS registration. Surfacing this needs either
+//   (1) hoisting MaybeStartDirectQueryServer earlier in the lifecycle
+//       (Stirling startup ordering currently blocks that), or
+//   (2) a "broker-optional" mode flag in the shared Manager base that
+//       lets PEMManager continue past a failed NATS Connect when
+//       direct-query is enabled (kelvin / metadata are unaffected).
+// Either approach is a separate, bigger PR than #29. Documented in
+// DIRECT_QUERY_SECURITY.md "Bidirectional fail-soft" follow-up. Flip
+// this from SKIP to PASS when the refactor lands.
+TEST_F(DirectQueryServerExecTest, FailSoft_BrokerFailureToleratedByDirectQuery) {
+  GTEST_SKIP() << "RED: PEMManager::PostRegisterHookImpl is gated on broker "
+                  "NATS registration; hoist MaybeStartDirectQueryServer or "
+                  "introduce a broker-optional Manager mode to close the "
+                  "contract. Tracked in DIRECT_QUERY_SECURITY.md.";
 }
 
 }  // namespace agent

--- a/src/vizier/services/agent/pem/direct_query_server_test.cc
+++ b/src/vizier/services/agent/pem/direct_query_server_test.cc
@@ -29,6 +29,7 @@
 #include <chrono>
 #include <memory>
 #include <string>
+#include <vector>  // std::vector for the aud-array mint
 
 #include <grpcpp/grpcpp.h>
 #include <grpcpp/security/server_credentials.h>
@@ -71,7 +72,13 @@ std::string MakeBearerToken(const std::string& signing_key, TokenKind kind) {
 
   jwt::jwt_object obj{jwt::params::algorithm("HS256")};
   obj.add_claim("iss", "PL");
-  obj.add_claim("aud", "vizier");
+  // RFC 7519 §4.1.3 + pixie's go mint convention (jwt.go:46
+  // Audience([]string{...})) serialize aud as a JSON array. The verifier
+  // (direct_query_server.cc) accepts both string and array forms, but the
+  // unit test mints the ARRAY form so it guards against a regression to
+  // string-only verification — dx-agent reports the live e2e would
+  // UNAUTHENTICATED if we drifted back.
+  obj.add_claim("aud", std::vector<std::string>{"vizier"});
   obj.add_claim("jti", "direct-query-test");
   obj.add_claim("iat", now);
   obj.add_claim("nbf", now - seconds{60});

--- a/src/vizier/services/agent/pem/direct_query_server_test.cc
+++ b/src/vizier/services/agent/pem/direct_query_server_test.cc
@@ -33,9 +33,15 @@
 #include <grpcpp/grpcpp.h>
 #include <grpcpp/security/server_credentials.h>
 #include <jwt/jwt.hpp>
+#include <sole.hpp>
 
 #include "src/api/proto/vizierpb/vizierapi.grpc.pb.h"
+#include "src/carnot/carnot.h"
+#include "src/carnot/exec/local_grpc_result_server.h"
+#include "src/carnot/funcs/funcs.h"
+#include "src/carnot/udf/registry.h"
 #include "src/common/testing/testing.h"
+#include "src/table_store/table_store.h"
 #include "src/vizier/services/agent/pem/direct_query_server.h"
 
 namespace px {
@@ -82,8 +88,8 @@ class DirectQueryServerTest : public ::testing::Test {
  protected:
   void SetUp() override {
     // carnot/engine/result_server null for the auth + scope-guard cases (no
-    // execution reached). Step 2: ValidToken_TrivialQuery_StreamsRows builds a
-    // real CarnotTest-style fixture in its own SetUp override.
+    // execution reached). Subclass DirectQueryServerExecTest below builds the
+    // real Carnot fixture for ValidToken_TrivialQuery_StreamsRows.
     service_ = std::make_unique<DirectQueryServer>(/*carnot*/ nullptr, /*engine_state*/ nullptr,
                                                    /*result_server*/ nullptr, kTestSigningKey);
     ::grpc::ServerBuilder builder;
@@ -139,13 +145,88 @@ TEST_F(DirectQueryServerTest, ValidToken_Mutation_Unimplemented) {
             CallExecuteScript(tok, /*mutation*/ true).error_code());
 }
 
-// 2. Valid token + trivial query → OK stream. Needs a Carnot fixture with a seeded
-// table; until SetUp() supplies one, this is the core red→green for the pem-agent.
-TEST_F(DirectQueryServerTest, ValidToken_TrivialQuery_StreamsRows) {
-  GTEST_SKIP() << "TODO(pem-agent): seed a Carnot fixture in SetUp(), then assert "
-                  "ExecuteScript returns OK and streams >=1 ExecuteScriptResponse.";
-  // auto tok = MakeBearerToken(kTestSigningKey, TokenKind::kValid);
-  // EXPECT_EQ(::grpc::StatusCode::OK, CallExecuteScript(tok).error_code());
+// 2. Valid token + trivial query → OK stream. The fixture below builds a
+// real CarnotTest-style table_store + Carnot + LocalGRPCResultSinkServer, then
+// passes them to DirectQueryServer, so ExecuteScript actually compiles and
+// runs the PxL.
+class DirectQueryServerExecTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    table_store_ = std::make_shared<::px::table_store::TableStore>();
+    result_server_ = std::make_unique<::px::carnot::exec::LocalGRPCResultSinkServer>();
+
+    auto func_registry = std::make_unique<::px::carnot::udf::Registry>("direct_query_test");
+    ::px::carnot::funcs::RegisterFuncsOrDie(func_registry.get());
+
+    auto clients_config =
+        std::make_unique<::px::carnot::Carnot::ClientsConfig>(::px::carnot::Carnot::ClientsConfig{
+            [this](const std::string& address, const std::string&) {
+              return result_server_->StubGenerator(address);
+            },
+            [](::grpc::ClientContext*) {},
+        });
+    auto server_config = std::make_unique<::px::carnot::Carnot::ServerConfig>();
+    server_config->grpc_server_creds = ::grpc::InsecureServerCredentials();
+    server_config->grpc_server_port = 0;
+
+    carnot_ = ::px::carnot::Carnot::Create(sole::uuid4(), std::move(func_registry), table_store_,
+                                           std::move(clients_config), std::move(server_config))
+                  .ConsumeValueOrDie();
+    table_store_->AddTable("http_events", MakeHTTPEventsTable());
+
+    service_ = std::make_unique<DirectQueryServer>(carnot_.get(), carnot_->GetEngineState(),
+                                                   result_server_.get(), kTestSigningKey);
+    ::grpc::ServerBuilder builder;
+    builder.RegisterService(service_.get());
+    server_ = builder.BuildAndStart();
+    stub_ = ::px::api::vizierpb::VizierService::NewStub(server_->InProcessChannel({}));
+  }
+
+  void TearDown() override {
+    if (server_) server_->Shutdown();
+  }
+
+  // Same schema as CarnotTestUtils::HTTPEventsTable — kept inline so we don't
+  // pull //src/carnot/exec:test_utils through a fragile alias. Empty (no rows
+  // appended) is fine for the trivial query: the PxL just enumerates the
+  // schema; the test asserts OK + >=1 streamed response.
+  std::shared_ptr<::px::table_store::Table> MakeHTTPEventsTable() {
+    ::px::table_store::schema::Relation rel(
+        {
+            ::px::types::DataType::TIME64NS,
+            ::px::types::DataType::UINT128,
+            ::px::types::DataType::STRING,
+            ::px::types::DataType::INT64,
+            ::px::types::DataType::INT64,
+        },
+        {"time_", "upid", "remote_addr", "remote_port", "trace_role"});
+    return ::px::table_store::Table::Create("http_events", rel);
+  }
+
+  std::shared_ptr<::px::table_store::TableStore> table_store_;
+  std::unique_ptr<::px::carnot::exec::LocalGRPCResultSinkServer> result_server_;
+  std::unique_ptr<::px::carnot::Carnot> carnot_;
+  std::unique_ptr<DirectQueryServer> service_;
+  std::unique_ptr<::grpc::Server> server_;
+  std::unique_ptr<::px::api::vizierpb::VizierService::Stub> stub_;
+};
+
+TEST_F(DirectQueryServerExecTest, ValidToken_TrivialQuery_StreamsRows) {
+  auto tok = MakeBearerToken(kTestSigningKey, TokenKind::kValid);
+  ::grpc::ClientContext ctx;
+  ctx.AddMetadata("authorization", "Bearer " + tok);
+  ::px::api::vizierpb::ExecuteScriptRequest req;
+  req.set_query_str("import px\npx.display(px.DataFrame('http_events'))");
+  req.set_mutation(false);
+  auto reader = stub_->ExecuteScript(&ctx, req);
+  int response_count = 0;
+  ::px::api::vizierpb::ExecuteScriptResponse resp;
+  while (reader->Read(&resp)) {
+    ++response_count;
+  }
+  auto status = reader->Finish();
+  EXPECT_EQ(::grpc::StatusCode::OK, status.error_code()) << status.error_message();
+  EXPECT_GE(response_count, 1) << "expected at least one ExecuteScriptResponse";
 }
 
 // 4. Metadata-connected per-pod filter returns only that pod's rows (closes #15 on

--- a/src/vizier/services/agent/pem/pem_main.cc
+++ b/src/vizier/services/agent/pem/pem_main.cc
@@ -38,6 +38,27 @@ DEFINE_string(clock_converter, gflags::StringFromEnv("PL_CLOCK_CONVERTER", "defa
               "Which ClockConverter to use for converting from mono to reference time. Current "
               "options are 'default' or 'grpc'");
 
+// entlein/dx#29 — direct-query gRPC endpoint on the normal PEM. See
+// src/vizier/services/agent/pem/DIRECT_QUERY_CONTRACT.md.
+// Default-OFF: flag false → port never opened → existing PEM deploys unchanged.
+// When true, pem_manager constructs DirectQueryServer against the PEM's live
+// Carnot + EngineState and binds the listener. PL_JWT_SIGNING_KEY shares the
+// existing manager.cc DEFINE_string(jwt_signing_key) env so a single secret
+// covers both the outgoing mint path and the incoming verify path.
+DEFINE_bool(direct_query_enabled,
+            gflags::BoolFromEnv("PL_PEM_DIRECT_QUERY_ENABLED", false),
+            "If true, expose VizierService::ExecuteScript directly from this PEM. "
+            "Default false; existing PEM deploys see no behavior change.");
+DEFINE_int32(direct_query_port,
+             gflags::Int32FromEnv("PL_PEM_DIRECT_QUERY_PORT", 50305),
+             "gRPC listen port for the direct-query service when "
+             "--direct_query_enabled=true.");
+DEFINE_string(direct_query_jwt_signing_key,
+              gflags::StringFromEnv("PL_JWT_SIGNING_KEY", ""),
+              "HMAC key the bearer JWT must verify against. Required when "
+              "--direct_query_enabled=true. Shared with the existing PEM-side "
+              "manager JWT mint path (manager.cc DEFINE_string(jwt_signing_key)).");
+
 using ::px::vizier::agent::DefaultDeathHandler;
 using ::px::vizier::agent::PEMManager;
 using ::px::vizier::agent::TerminationHandler;

--- a/src/vizier/services/agent/pem/pem_main.cc
+++ b/src/vizier/services/agent/pem/pem_main.cc
@@ -45,16 +45,13 @@ DEFINE_string(clock_converter, gflags::StringFromEnv("PL_CLOCK_CONVERTER", "defa
 // Carnot + EngineState and binds the listener. PL_JWT_SIGNING_KEY shares the
 // existing manager.cc DEFINE_string(jwt_signing_key) env so a single secret
 // covers both the outgoing mint path and the incoming verify path.
-DEFINE_bool(direct_query_enabled,
-            gflags::BoolFromEnv("PL_PEM_DIRECT_QUERY_ENABLED", false),
+DEFINE_bool(direct_query_enabled, gflags::BoolFromEnv("PL_PEM_DIRECT_QUERY_ENABLED", false),
             "If true, expose VizierService::ExecuteScript directly from this PEM. "
             "Default false; existing PEM deploys see no behavior change.");
-DEFINE_int32(direct_query_port,
-             gflags::Int32FromEnv("PL_PEM_DIRECT_QUERY_PORT", 50305),
+DEFINE_int32(direct_query_port, gflags::Int32FromEnv("PL_PEM_DIRECT_QUERY_PORT", 50305),
              "gRPC listen port for the direct-query service when "
              "--direct_query_enabled=true.");
-DEFINE_string(direct_query_jwt_signing_key,
-              gflags::StringFromEnv("PL_JWT_SIGNING_KEY", ""),
+DEFINE_string(direct_query_jwt_signing_key, gflags::StringFromEnv("PL_JWT_SIGNING_KEY", ""),
               "HMAC key the bearer JWT must verify against. Required when "
               "--direct_query_enabled=true. Shared with the existing PEM-side "
               "manager JWT mint path (manager.cc DEFINE_string(jwt_signing_key)).");

--- a/src/vizier/services/agent/pem/pem_main.cc
+++ b/src/vizier/services/agent/pem/pem_main.cc
@@ -38,23 +38,10 @@ DEFINE_string(clock_converter, gflags::StringFromEnv("PL_CLOCK_CONVERTER", "defa
               "Which ClockConverter to use for converting from mono to reference time. Current "
               "options are 'default' or 'grpc'");
 
-// entlein/dx#29 — direct-query gRPC endpoint on the normal PEM. See
-// src/vizier/services/agent/pem/DIRECT_QUERY_CONTRACT.md.
-// Default-OFF: flag false → port never opened → existing PEM deploys unchanged.
-// When true, pem_manager constructs DirectQueryServer against the PEM's live
-// Carnot + EngineState and binds the listener. PL_JWT_SIGNING_KEY shares the
-// existing manager.cc DEFINE_string(jwt_signing_key) env so a single secret
-// covers both the outgoing mint path and the incoming verify path.
-DEFINE_bool(direct_query_enabled, gflags::BoolFromEnv("PL_PEM_DIRECT_QUERY_ENABLED", false),
-            "If true, expose VizierService::ExecuteScript directly from this PEM. "
-            "Default false; existing PEM deploys see no behavior change.");
-DEFINE_int32(direct_query_port, gflags::Int32FromEnv("PL_PEM_DIRECT_QUERY_PORT", 50305),
-             "gRPC listen port for the direct-query service when "
-             "--direct_query_enabled=true.");
-DEFINE_string(direct_query_jwt_signing_key, gflags::StringFromEnv("PL_JWT_SIGNING_KEY", ""),
-              "HMAC key the bearer JWT must verify against. Required when "
-              "--direct_query_enabled=true. Shared with the existing PEM-side "
-              "manager JWT mint path (manager.cc DEFINE_string(jwt_signing_key)).");
+// entlein/dx#29 — direct-query gRPC flags (--direct_query_enabled / _port /
+// _jwt_signing_key, env PL_PEM_DIRECT_QUERY_* + PL_JWT_SIGNING_KEY) are
+// DEFINEd in pem_manager.cc so the test binary (which links cc_library but
+// not pem_main.cc) picks up the symbols. See DIRECT_QUERY_CONTRACT.md.
 
 using ::px::vizier::agent::DefaultDeathHandler;
 using ::px::vizier::agent::PEMManager;

--- a/src/vizier/services/agent/pem/pem_manager.cc
+++ b/src/vizier/services/agent/pem/pem_manager.cc
@@ -26,9 +26,20 @@
 #include "src/vizier/services/agent/shared/manager/exec.h"
 #include "src/vizier/services/agent/shared/manager/manager.h"
 
-DECLARE_bool(direct_query_enabled);
-DECLARE_int32(direct_query_port);
-DECLARE_string(direct_query_jwt_signing_key);
+// entlein/dx#29 — direct-query gRPC endpoint on the normal PEM. Defined here
+// (not in pem_main.cc) so the test binary, which links cc_library but not
+// pem_main.cc, picks up the symbol. Default-OFF: flag false → port never
+// opened → existing PEM deploys unchanged. See DIRECT_QUERY_CONTRACT.md.
+DEFINE_bool(direct_query_enabled, gflags::BoolFromEnv("PL_PEM_DIRECT_QUERY_ENABLED", false),
+            "If true, expose VizierService::ExecuteScript directly from this PEM. "
+            "Default false; existing PEM deploys see no behavior change.");
+DEFINE_int32(direct_query_port, gflags::Int32FromEnv("PL_PEM_DIRECT_QUERY_PORT", 50305),
+             "gRPC listen port for the direct-query service when "
+             "--direct_query_enabled=true.");
+DEFINE_string(direct_query_jwt_signing_key, gflags::StringFromEnv("PL_JWT_SIGNING_KEY", ""),
+              "HMAC key the bearer JWT must verify against. Required when "
+              "--direct_query_enabled=true. Shared with the existing PEM-side "
+              "manager JWT mint path (manager.cc DEFINE_string(jwt_signing_key)).");
 
 DEFINE_int32(
     table_store_data_limit, gflags::Int32FromEnv("PL_TABLE_STORE_DATA_LIMIT_MB", 1024 + 256),

--- a/src/vizier/services/agent/pem/pem_manager.cc
+++ b/src/vizier/services/agent/pem/pem_manager.cc
@@ -18,9 +18,17 @@
 
 #include "src/vizier/services/agent/pem/pem_manager.h"
 
+#include <absl/strings/substitute.h>
+
+#include "src/carnot/funcs/funcs.h"
+#include "src/carnot/udf/registry.h"
 #include "src/common/system/config.h"
 #include "src/vizier/services/agent/shared/manager/exec.h"
 #include "src/vizier/services/agent/shared/manager/manager.h"
+
+DECLARE_bool(direct_query_enabled);
+DECLARE_int32(direct_query_port);
+DECLARE_string(direct_query_jwt_signing_key);
 
 DEFINE_int32(
     table_store_data_limit, gflags::Int32FromEnv("PL_TABLE_STORE_DATA_LIMIT_MB", 1024 + 256),
@@ -78,10 +86,82 @@ Status PEMManager::PostRegisterHookImpl() {
                                           stirling_.get(), table_store(), relation_info_manager());
   PX_RETURN_IF_ERROR(RegisterMessageHandler(messages::VizierMessage::MsgCase::kTracepointMessage,
                                             tracepoint_manager_));
+  PX_RETURN_IF_ERROR(MaybeStartDirectQueryServer());
   return Status::OK();
 }
 
+Status PEMManager::MaybeStartDirectQueryServer() {
+  if (!FLAGS_direct_query_enabled) {
+    LOG(INFO) << "direct-query: disabled (--direct_query_enabled=false)";
+    return Status::OK();
+  }
+  if (FLAGS_direct_query_jwt_signing_key.empty()) {
+    return error::InvalidArgument(
+        "direct-query: --direct_query_enabled=true but signing key is empty "
+        "(set PL_JWT_SIGNING_KEY)");
+  }
+  // Construct a Carnot dedicated to direct-query calls, sharing the base
+  // manager's table_store + metadata callback (no duplicate data plane).
+  // dx-agent's contract requires reusing the live Carnot's data state; the
+  // production base Carnot ships results to Kelvin via its server_config,
+  // which we can't redirect per-call. A dedicated direct_query_carnot_ that
+  // points at our LocalGRPCResultSinkServer is the smallest delta that keeps
+  // results node-local for the direct-query path.
+  direct_query_sink_ = std::make_unique<carnot::exec::LocalGRPCResultSinkServer>();
+
+  auto func_registry = std::make_unique<carnot::udf::Registry>("direct_query_registry");
+  carnot::funcs::RegisterFuncsOrDie(func_registry.get());
+
+  auto clients_config =
+      std::make_unique<carnot::Carnot::ClientsConfig>(carnot::Carnot::ClientsConfig{
+          [this](const std::string& address, const std::string&) {
+            return direct_query_sink_->StubGenerator(address);
+          },
+          [](::grpc::ClientContext*) {},
+      });
+  auto server_config = std::make_unique<carnot::Carnot::ServerConfig>();
+  server_config->grpc_server_creds = ::grpc::InsecureServerCredentials();
+  server_config->grpc_server_port = 0;
+
+  std::shared_ptr<table_store::TableStore> ts(table_store(), [](table_store::TableStore*) {});
+  auto carnot_or = carnot::Carnot::Create(info()->agent_id, std::move(func_registry), ts,
+                                          std::move(clients_config), std::move(server_config));
+  if (!carnot_or.ok()) {
+    return error::Internal("direct-query: failed to construct local Carnot: $0",
+                           carnot_or.status().msg());
+  }
+  direct_query_carnot_ = carnot_or.ConsumeValueOrDie();
+  direct_query_carnot_->RegisterAgentMetadataCallback(
+      std::bind(&::px::md::AgentMetadataStateManager::CurrentAgentMetadataState, mds_manager()));
+
+  direct_query_service_ = std::make_unique<DirectQueryServer>(
+      direct_query_carnot_.get(), direct_query_carnot_->GetEngineState(),
+      direct_query_sink_.get(), FLAGS_direct_query_jwt_signing_key);
+
+  ::grpc::ServerBuilder builder;
+  const std::string addr = absl::Substitute("0.0.0.0:$0", FLAGS_direct_query_port);
+  builder.AddListeningPort(addr, ::grpc::InsecureServerCredentials());
+  builder.RegisterService(direct_query_service_.get());
+  direct_query_grpc_server_ = builder.BuildAndStart();
+  if (direct_query_grpc_server_ == nullptr) {
+    return error::Internal("direct-query: BuildAndStart returned null for $0", addr);
+  }
+  LOG(INFO) << "direct-query: gRPC ExecuteScript listening on " << addr;
+  return Status::OK();
+}
+
+void PEMManager::StopDirectQueryServer() {
+  if (direct_query_grpc_server_) {
+    direct_query_grpc_server_->Shutdown();
+    direct_query_grpc_server_.reset();
+  }
+  direct_query_service_.reset();
+  direct_query_carnot_.reset();
+  direct_query_sink_.reset();
+}
+
 Status PEMManager::StopImpl(std::chrono::milliseconds) {
+  StopDirectQueryServer();
   stirling_->Stop();
   stirling_.reset();
   return Status::OK();

--- a/src/vizier/services/agent/pem/pem_manager.cc
+++ b/src/vizier/services/agent/pem/pem_manager.cc
@@ -30,6 +30,13 @@
 // (not in pem_main.cc) so the test binary, which links cc_library but not
 // pem_main.cc, picks up the symbol. Default-OFF: flag false → port never
 // opened → existing PEM deploys unchanged. See DIRECT_QUERY_CONTRACT.md.
+//
+// Compile-time disable: when PX_PEM_DIRECT_QUERY_DISABLED is defined
+// (`--//src/vizier/services/agent/pem:direct_query=disabled`), the gflags
+// registrations + the runtime feature flag are EXCLUDED from the binary
+// entirely. Operators who do not want direct-query available even as a
+// disabled-by-default option get a binary with zero direct-query bytes.
+#ifndef PX_PEM_DIRECT_QUERY_DISABLED
 DEFINE_bool(direct_query_enabled, gflags::BoolFromEnv("PL_PEM_DIRECT_QUERY_ENABLED", false),
             "If true, expose VizierService::ExecuteScript directly from this PEM. "
             "Default false; existing PEM deploys see no behavior change.");
@@ -48,6 +55,7 @@ DEFINE_string(direct_query_jwt_signing_key, gflags::StringFromEnv("PL_JWT_SIGNIN
 // where a CLI override of only one flag silently disables direct-query auth.
 // The actual DEFINE_string(jwt_signing_key, …) lives in shared/manager/manager.cc.
 DECLARE_string(jwt_signing_key);
+#endif  // PX_PEM_DIRECT_QUERY_DISABLED
 
 DEFINE_int32(
     table_store_data_limit, gflags::Int32FromEnv("PL_TABLE_STORE_DATA_LIMIT_MB", 1024 + 256),
@@ -121,6 +129,13 @@ Status PEMManager::PostRegisterHookImpl() {
 // Each step also emits a LOG(INFO) breadcrumb so a future crashloop pin-
 // points the exact failure line in stderr (--previous capture, canary etc.).
 Status PEMManager::MaybeStartDirectQueryServer() {
+#ifdef PX_PEM_DIRECT_QUERY_DISABLED
+  // Compile-time kill switch. Zero direct-query bytes in the binary — no
+  // gflag registrations, no JWT verifier, no Carnot, no gRPC server. The
+  // runtime --direct_query_enabled flag does not exist in this build.
+  LOG(INFO) << "direct-query: compiled out (PX_PEM_DIRECT_QUERY_DISABLED)";
+  return Status::OK();
+#else
   if (!FLAGS_direct_query_enabled) {
     LOG(INFO) << "direct-query: disabled (--direct_query_enabled=false)";
     return Status::OK();
@@ -212,6 +227,7 @@ Status PEMManager::MaybeStartDirectQueryServer() {
     direct_query_sink_.reset();
   }
   return Status::OK();
+#endif  // PX_PEM_DIRECT_QUERY_DISABLED
 }
 
 void PEMManager::StopDirectQueryServer() {

--- a/src/vizier/services/agent/pem/pem_manager.cc
+++ b/src/vizier/services/agent/pem/pem_manager.cc
@@ -101,63 +101,98 @@ Status PEMManager::PostRegisterHookImpl() {
   return Status::OK();
 }
 
+// MaybeStartDirectQueryServer is FAIL-SOFT. pemdq4 (commit 9ce6fbdb4) was
+// observed to crashloop the live PEM with `exit=1` and `:50305 never bound`
+// when this returned an error from PostRegisterHookImpl — the base manager
+// PX_CHECK_OK's its result and the entire data plane goes down. Direct-query
+// is an OPTIONAL feature on the PEM; an init failure here must never take
+// the data plane with it. Every failure path now logs+swallows and returns
+// Status::OK() so the rest of the PEM stays up; dx_daemon sees a
+// "connection refused" on :50305 which is harmless on the broker path.
+//
+// Each step also emits a LOG(INFO) breadcrumb so a future crashloop pin-
+// points the exact failure line in stderr (--previous capture, canary etc.).
 Status PEMManager::MaybeStartDirectQueryServer() {
   if (!FLAGS_direct_query_enabled) {
     LOG(INFO) << "direct-query: disabled (--direct_query_enabled=false)";
     return Status::OK();
   }
+  LOG(INFO) << "direct-query: start (port=" << FLAGS_direct_query_port << ")";
   if (FLAGS_direct_query_jwt_signing_key.empty()) {
-    return error::InvalidArgument(
-        "direct-query: --direct_query_enabled=true but signing key is empty "
-        "(set PL_JWT_SIGNING_KEY)");
+    LOG(ERROR) << "direct-query: --direct_query_enabled=true but signing key is empty "
+                  "(set PL_JWT_SIGNING_KEY) — staying up, direct-query disabled";
+    return Status::OK();
   }
-  // Construct a Carnot dedicated to direct-query calls, sharing the base
-  // manager's table_store + metadata callback (no duplicate data plane).
-  // dx-agent's contract requires reusing the live Carnot's data state; the
-  // production base Carnot ships results to Kelvin via its server_config,
-  // which we can't redirect per-call. A dedicated direct_query_carnot_ that
-  // points at our LocalGRPCResultSinkServer is the smallest delta that keeps
-  // results node-local for the direct-query path.
-  direct_query_sink_ = std::make_unique<carnot::exec::LocalGRPCResultSinkServer>();
+  try {
+    LOG(INFO) << "direct-query: step 1/6 create sink server";
+    direct_query_sink_ = std::make_unique<carnot::exec::LocalGRPCResultSinkServer>();
 
-  auto func_registry = std::make_unique<carnot::udf::Registry>("direct_query_registry");
-  carnot::funcs::RegisterFuncsOrDie(func_registry.get());
+    LOG(INFO) << "direct-query: step 2/6 register udfs";
+    auto func_registry = std::make_unique<carnot::udf::Registry>("direct_query_registry");
+    carnot::funcs::RegisterFuncsOrDie(func_registry.get());
 
-  auto clients_config =
-      std::make_unique<carnot::Carnot::ClientsConfig>(carnot::Carnot::ClientsConfig{
-          [this](const std::string& address, const std::string&) {
-            return direct_query_sink_->StubGenerator(address);
-          },
-          [](::grpc::ClientContext*) {},
-      });
-  auto server_config = std::make_unique<carnot::Carnot::ServerConfig>();
-  server_config->grpc_server_creds = ::grpc::InsecureServerCredentials();
-  server_config->grpc_server_port = 0;
+    LOG(INFO) << "direct-query: step 3/6 build carnot configs";
+    auto clients_config =
+        std::make_unique<carnot::Carnot::ClientsConfig>(carnot::Carnot::ClientsConfig{
+            [this](const std::string& address, const std::string&) {
+              return direct_query_sink_->StubGenerator(address);
+            },
+            [](::grpc::ClientContext*) {},
+        });
+    auto server_config = std::make_unique<carnot::Carnot::ServerConfig>();
+    server_config->grpc_server_creds = ::grpc::InsecureServerCredentials();
+    server_config->grpc_server_port = 0;
 
-  std::shared_ptr<table_store::TableStore> ts(table_store(), [](table_store::TableStore*) {});
-  auto carnot_or = carnot::Carnot::Create(info()->agent_id, std::move(func_registry), ts,
-                                          std::move(clients_config), std::move(server_config));
-  if (!carnot_or.ok()) {
-    return error::Internal("direct-query: failed to construct local Carnot: $0",
-                           carnot_or.status().msg());
+    LOG(INFO) << "direct-query: step 4/6 Carnot::Create";
+    std::shared_ptr<table_store::TableStore> ts(table_store(), [](table_store::TableStore*) {});
+    auto carnot_or = carnot::Carnot::Create(info()->agent_id, std::move(func_registry), ts,
+                                            std::move(clients_config), std::move(server_config));
+    if (!carnot_or.ok()) {
+      LOG(ERROR) << "direct-query: Carnot::Create failed: " << carnot_or.status().msg()
+                 << " — staying up, direct-query disabled";
+      direct_query_sink_.reset();
+      return Status::OK();
+    }
+    direct_query_carnot_ = carnot_or.ConsumeValueOrDie();
+    direct_query_carnot_->RegisterAgentMetadataCallback(
+        std::bind(&::px::md::AgentMetadataStateManager::CurrentAgentMetadataState, mds_manager()));
+
+    LOG(INFO) << "direct-query: step 5/6 build DirectQueryServer";
+    direct_query_service_ = std::make_unique<DirectQueryServer>(
+        direct_query_carnot_.get(), direct_query_carnot_->GetEngineState(),
+        direct_query_sink_.get(), FLAGS_direct_query_jwt_signing_key);
+
+    LOG(INFO) << "direct-query: step 6/6 grpc BuildAndStart on :"
+              << FLAGS_direct_query_port;
+    ::grpc::ServerBuilder builder;
+    const std::string addr = absl::Substitute("0.0.0.0:$0", FLAGS_direct_query_port);
+    builder.AddListeningPort(addr, ::grpc::InsecureServerCredentials());
+    builder.RegisterService(direct_query_service_.get());
+    direct_query_grpc_server_ = builder.BuildAndStart();
+    if (direct_query_grpc_server_ == nullptr) {
+      LOG(ERROR) << "direct-query: BuildAndStart returned null for " << addr
+                 << " — staying up, direct-query disabled";
+      direct_query_service_.reset();
+      direct_query_carnot_.reset();
+      direct_query_sink_.reset();
+      return Status::OK();
+    }
+    LOG(INFO) << "direct-query: READY — gRPC ExecuteScript listening on " << addr;
+  } catch (const std::exception& e) {
+    LOG(ERROR) << "direct-query: exception during setup: " << e.what()
+               << " — staying up, direct-query disabled";
+    direct_query_grpc_server_.reset();
+    direct_query_service_.reset();
+    direct_query_carnot_.reset();
+    direct_query_sink_.reset();
+  } catch (...) {
+    LOG(ERROR) << "direct-query: non-std exception during setup — staying up, "
+                  "direct-query disabled";
+    direct_query_grpc_server_.reset();
+    direct_query_service_.reset();
+    direct_query_carnot_.reset();
+    direct_query_sink_.reset();
   }
-  direct_query_carnot_ = carnot_or.ConsumeValueOrDie();
-  direct_query_carnot_->RegisterAgentMetadataCallback(
-      std::bind(&::px::md::AgentMetadataStateManager::CurrentAgentMetadataState, mds_manager()));
-
-  direct_query_service_ = std::make_unique<DirectQueryServer>(
-      direct_query_carnot_.get(), direct_query_carnot_->GetEngineState(),
-      direct_query_sink_.get(), FLAGS_direct_query_jwt_signing_key);
-
-  ::grpc::ServerBuilder builder;
-  const std::string addr = absl::Substitute("0.0.0.0:$0", FLAGS_direct_query_port);
-  builder.AddListeningPort(addr, ::grpc::InsecureServerCredentials());
-  builder.RegisterService(direct_query_service_.get());
-  direct_query_grpc_server_ = builder.BuildAndStart();
-  if (direct_query_grpc_server_ == nullptr) {
-    return error::Internal("direct-query: BuildAndStart returned null for $0", addr);
-  }
-  LOG(INFO) << "direct-query: gRPC ExecuteScript listening on " << addr;
   return Status::OK();
 }
 

--- a/src/vizier/services/agent/pem/pem_manager.cc
+++ b/src/vizier/services/agent/pem/pem_manager.cc
@@ -25,6 +25,7 @@
 #include "src/common/system/config.h"
 #include "src/vizier/services/agent/shared/manager/exec.h"
 #include "src/vizier/services/agent/shared/manager/manager.h"
+#include "src/vizier/services/agent/shared/manager/ssl.h"
 
 // entlein/dx#29 — direct-query gRPC endpoint on the normal PEM. Defined here
 // (not in pem_main.cc) so the test binary, which links cc_library but not
@@ -174,7 +175,14 @@ Status PEMManager::MaybeStartDirectQueryServer() {
             [](::grpc::ClientContext*) {},
         });
     auto server_config = std::make_unique<carnot::Carnot::ServerConfig>();
-    server_config->grpc_server_creds = ::grpc::InsecureServerCredentials();
+    // SSL::DefaultGRPCServerCreds reuses the PEM's cluster-mounted certs
+    // (tls_ca_crt + client_tls_cert + client_tls_key). PL_DISABLE_SSL=1
+    // falls back to insecure for dev/soak clusters — matches manager.cc's
+    // base Carnot setup. Carnot's internal sink uses InProcessChannel
+    // (LocalGRPCResultSinkServer::StubGenerator), so this credential is
+    // exercised only when an external client opens a TCP channel; defense
+    // in depth still calls for matching the cluster's TLS policy.
+    server_config->grpc_server_creds = SSL::DefaultGRPCServerCreds();
     server_config->grpc_server_port = 0;
 
     LOG(INFO) << "direct-query: step 4/6 Carnot::Create";
@@ -199,7 +207,14 @@ Status PEMManager::MaybeStartDirectQueryServer() {
     LOG(INFO) << "direct-query: step 6/6 grpc BuildAndStart on :" << FLAGS_direct_query_port;
     ::grpc::ServerBuilder builder;
     const std::string addr = absl::Substitute("0.0.0.0:$0", FLAGS_direct_query_port);
-    builder.AddListeningPort(addr, ::grpc::InsecureServerCredentials());
+    // Cluster-default TLS — the JWT bearer flowing over this socket MUST
+    // NOT be plaintext on the pod network. SSL::DefaultGRPCServerCreds
+    // pulls the same in-cluster cert pair kelvin / metadata / the broker
+    // use (mounted via secretKeyRef in the PEM DaemonSet). Dev/soak
+    // clusters where the operator sets PL_DISABLE_SSL=1 still get an
+    // insecure channel — that's an EXPLICIT operator choice, not a
+    // silent default. See DIRECT_QUERY_SECURITY.md "Transport".
+    builder.AddListeningPort(addr, SSL::DefaultGRPCServerCreds());
     builder.RegisterService(direct_query_service_.get());
     direct_query_grpc_server_ = builder.BuildAndStart();
     if (direct_query_grpc_server_ == nullptr) {

--- a/src/vizier/services/agent/pem/pem_manager.cc
+++ b/src/vizier/services/agent/pem/pem_manager.cc
@@ -162,8 +162,7 @@ Status PEMManager::MaybeStartDirectQueryServer() {
         direct_query_carnot_.get(), direct_query_carnot_->GetEngineState(),
         direct_query_sink_.get(), FLAGS_direct_query_jwt_signing_key);
 
-    LOG(INFO) << "direct-query: step 6/6 grpc BuildAndStart on :"
-              << FLAGS_direct_query_port;
+    LOG(INFO) << "direct-query: step 6/6 grpc BuildAndStart on :" << FLAGS_direct_query_port;
     ::grpc::ServerBuilder builder;
     const std::string addr = absl::Substitute("0.0.0.0:$0", FLAGS_direct_query_port);
     builder.AddListeningPort(addr, ::grpc::InsecureServerCredentials());

--- a/src/vizier/services/agent/pem/pem_manager.cc
+++ b/src/vizier/services/agent/pem/pem_manager.cc
@@ -37,9 +37,17 @@ DEFINE_int32(direct_query_port, gflags::Int32FromEnv("PL_PEM_DIRECT_QUERY_PORT",
              "gRPC listen port for the direct-query service when "
              "--direct_query_enabled=true.");
 DEFINE_string(direct_query_jwt_signing_key, gflags::StringFromEnv("PL_JWT_SIGNING_KEY", ""),
-              "HMAC key the bearer JWT must verify against. Required when "
-              "--direct_query_enabled=true. Shared with the existing PEM-side "
-              "manager JWT mint path (manager.cc DEFINE_string(jwt_signing_key)).");
+              "HMAC key the bearer JWT must verify against. Optional; when "
+              "empty, falls back to the shared manager JWT mint key "
+              "(--jwt_signing_key in manager.cc, same PL_JWT_SIGNING_KEY env). "
+              "Required only if you want direct-query verification to use a "
+              "different key from the agent's outgoing-mint key.");
+
+// Declared (not defined) here so MaybeStartDirectQueryServer can fall back to
+// it when --direct_query_jwt_signing_key is unset — avoids the split-brain
+// where a CLI override of only one flag silently disables direct-query auth.
+// The actual DEFINE_string(jwt_signing_key, …) lives in shared/manager/manager.cc.
+DECLARE_string(jwt_signing_key);
 
 DEFINE_int32(
     table_store_data_limit, gflags::Int32FromEnv("PL_TABLE_STORE_DATA_LIMIT_MB", 1024 + 256),
@@ -118,8 +126,19 @@ Status PEMManager::MaybeStartDirectQueryServer() {
     return Status::OK();
   }
   LOG(INFO) << "direct-query: start (port=" << FLAGS_direct_query_port << ")";
-  if (FLAGS_direct_query_jwt_signing_key.empty()) {
-    LOG(ERROR) << "direct-query: --direct_query_enabled=true but signing key is empty "
+  // Fall back to the shared manager key when the direct-query-specific flag is
+  // empty (the common case — both flags share PL_JWT_SIGNING_KEY by default,
+  // but a CLI override of one without the other would otherwise leave
+  // direct-query silently disabled). Manager::Init has already refused to
+  // start with an empty FLAGS_jwt_signing_key, so the only way to land here
+  // with effective_signing_key empty is an explicit
+  // --direct_query_jwt_signing_key='' override while --jwt_signing_key was
+  // also intentionally cleared — treat that as "direct-query disabled".
+  const std::string& effective_signing_key = FLAGS_direct_query_jwt_signing_key.empty()
+                                                 ? FLAGS_jwt_signing_key
+                                                 : FLAGS_direct_query_jwt_signing_key;
+  if (effective_signing_key.empty()) {
+    LOG(ERROR) << "direct-query: --direct_query_enabled=true but both signing keys are empty "
                   "(set PL_JWT_SIGNING_KEY) — staying up, direct-query disabled";
     return Status::OK();
   }
@@ -160,7 +179,7 @@ Status PEMManager::MaybeStartDirectQueryServer() {
     LOG(INFO) << "direct-query: step 5/6 build DirectQueryServer";
     direct_query_service_ = std::make_unique<DirectQueryServer>(
         direct_query_carnot_.get(), direct_query_carnot_->GetEngineState(),
-        direct_query_sink_.get(), FLAGS_direct_query_jwt_signing_key);
+        direct_query_sink_.get(), effective_signing_key);
 
     LOG(INFO) << "direct-query: step 6/6 grpc BuildAndStart on :" << FLAGS_direct_query_port;
     ::grpc::ServerBuilder builder;

--- a/src/vizier/services/agent/pem/pem_manager.h
+++ b/src/vizier/services/agent/pem/pem_manager.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <grpcpp/grpcpp.h>
 #include <chrono>
 #include <memory>
 #include <numeric>
@@ -26,8 +27,11 @@
 
 #include <prometheus/gauge.h>
 
+#include "src/carnot/carnot.h"
+#include "src/carnot/exec/local_grpc_result_server.h"
 #include "src/common/system/kernel_version.h"
 #include "src/stirling/stirling.h"
+#include "src/vizier/services/agent/pem/direct_query_server.h"
 #include "src/vizier/services/agent/pem/tracepoint_manager.h"
 #include "src/vizier/services/agent/shared/manager/manager.h"
 
@@ -101,6 +105,20 @@ class PEMManager : public Manager {
         FLAGS_stirling_profiler_stack_trace_sample_period_ms);
     return parameters;
   }
+
+  // entlein/dx#29 — direct-query gRPC endpoint on the live PEM. All four are
+  // nullptr when FLAGS_direct_query_enabled is false (the default), so the
+  // PEM stays byte-identical to the prior behavior. When the flag is on,
+  // PostRegisterHookImpl stands them up (sharing the base manager's
+  // table_store + agent metadata callback so we satisfy the contract's
+  // "reuse the live Carnot state" requirement: only the engine + sink are
+  // additive, no duplicate data plane) and StopImpl tears them down.
+  Status MaybeStartDirectQueryServer();
+  void StopDirectQueryServer();
+  std::unique_ptr<carnot::exec::LocalGRPCResultSinkServer> direct_query_sink_;
+  std::unique_ptr<carnot::Carnot> direct_query_carnot_;
+  std::unique_ptr<DirectQueryServer> direct_query_service_;
+  std::unique_ptr<grpc::Server> direct_query_grpc_server_;
 
   std::unique_ptr<stirling::Stirling> stirling_;
   std::shared_ptr<TracepointManager> tracepoint_manager_;

--- a/src/vizier/services/agent/shared/manager/manager.cc
+++ b/src/vizier/services/agent/shared/manager/manager.cc
@@ -138,6 +138,23 @@ Manager::Manager(sole::uuid agent_id, std::string_view pod_name, std::string_vie
 }
 
 Status Manager::Init() {
+  // Fail fast if PL_JWT_SIGNING_KEY is unset. GenerateServiceToken (below)
+  // calls cpp_jwt's obj.signature() which throws an uncaught
+  // jwt::SigningError("key not provided") when the secret is empty. That
+  // throw lands in the first outgoing gRPC AddServiceTokenToClientContext
+  // (typically the PEM's first query execution against Kelvin), so without
+  // this guard the agent runs for a while and then crashes mid-stream with
+  // libc++abi terminate — observed on the stock fork 0.14.17 PEM in
+  // CrashLoopBackOff for hours. Refuse to start instead. dx-agent flagged
+  // via entlein/dx#29 PR #49 soak.
+  if (FLAGS_jwt_signing_key.empty()) {
+    return error::InvalidArgument(
+        "PL_JWT_SIGNING_KEY is unset; refusing to start. The agent's outgoing "
+        "service-token mint (GenerateServiceToken) will throw "
+        "jwt::SigningError on the first call and crash the process. Set "
+        "PL_JWT_SIGNING_KEY via the pl-cluster-secrets/jwt-signing-key "
+        "secretKeyRef (already in k8s/vizier/pem/base/pem_daemonset.yaml).");
+  }
   PX_ASSIGN_OR_RETURN(
       agent_metadata_filter_,
       md::AgentMetadataFilter::Create(kMetadataFilterMaxEntries, kMetadataFilterMaxErrorRate,


### PR DESCRIPTION
Summary: PEM direct-query gRPC endpoint (entlein/dx#29). Make the metadata-connected vizier-pem serve api.vizierpb.VizierService.ExecuteScript directly over gRPC, JWT-authenticated, so dx queries the node-local PEM with no broker hop. Ports the standalone_pem capability with two upgrades: metadata-connected reuse of the live PEM Carnot + agent metadata (closes #15), and HS256 service-token auth via the cluster jwt-signing-key (no longer insecure). Drain fix (execution_and_timing_info -> QueryData.execution_stats wire-roundtrip + skip payload-less responses) closes the unimplemented type stream error caught on live PEM soak. Fail-soft direct-query startup (try/catch + step 1/6 to 6/6 breadcrumbs) so init failure can never crashloop the data plane. Manager::Init refuses to start with empty PL_JWT_SIGNING_KEY (catches the jwt::SigningError that crashloop'd the stock 0.14.17 PEM).

Relevant Issues: entlein/dx#29 (PEM direct-query)

Type of change: /kind feature

Test Plan: bazel test //src/vizier/services/agent/pem:direct_query_server_test (auth-negative + ValidToken_TrivialQuery_StreamsRows green); bazel test //src/vizier/services/agent/shared/manager/... (5/5 pass, JWT guard wired through Manager::Init); vizier-release CI builds pemdq6 image (commit 50dffb065 / tag release/vizier/v0.14.19-pemdq6); live PG soak