### PR TITLE
adaptive_export: ship conn_stats in the canonical schema (AE owns its table DDL)

### DIFF
--- a/src/vizier/services/adaptive_export/internal/clickhouse/ddl.go
+++ b/src/vizier/services/adaptive_export/internal/clickhouse/ddl.go
@@ -54,6 +54,7 @@ var KnownTables = []string{
 	"amqp_events",
 	"mux_events",
 	"tls_events",
+	"conn_stats",
 	// operator-owned attribution table
 	"adaptive_attribution",
 	// operator-owned persistent trigger cursor
@@ -106,6 +107,7 @@ func PixieTables() []string {
 		"amqp_events",
 		"mux_events",
 		"tls_events",
+		"conn_stats",
 	}
 }
 

--- a/src/vizier/services/adaptive_export/internal/clickhouse/ddl_test.go
+++ b/src/vizier/services/adaptive_export/internal/clickhouse/ddl_test.go
@@ -110,7 +110,7 @@ func TestDDL_KubescapeLogs_PreservesAnomalyHash(t *testing.T) {
 
 // TestDDL_UnknownTable_ErrUnknownTable — defensive contract.
 func TestDDL_UnknownTable_ErrUnknownTable(t *testing.T) {
-	for _, bad := range []string{"", "no_such_table", "process_events", "conn_stats"} {
+	for _, bad := range []string{"", "no_such_table", "process_events", "process_stats"} {
 		_, err := DDL(bad)
 		if !errors.Is(err, ErrUnknownTable) {
 			t.Fatalf("DDL(%q) → %v, want ErrUnknownTable", bad, err)

--- a/src/vizier/services/adaptive_export/internal/clickhouse/schema.sql
+++ b/src/vizier/services/adaptive_export/internal/clickhouse/schema.sql
@@ -352,6 +352,34 @@ CREATE TABLE IF NOT EXISTS forensic_db.tls_events (
   PARTITION BY toYYYYMM(event_time)
   ORDER BY (hostname, event_time);
 
+-- conn_stats — conn_stats_table.h (connection-level socket stats: bytes/conns per
+-- client-server pair). AE writes this (dx#5 forensic conn evidence) but it was
+-- previously OMITTED from this schema, so aeprod4 — which requires it — crashlooped
+-- on every fresh PG (dx#43). Now shipped by AE like every other table. Columns
+-- mirror pixie src/stirling/.../conn_stats_table.h (no local_addr/local_port; ssl
+-- in place of http's encrypted) + AE's namespace/pod/hostname/event_time convention.
+CREATE TABLE IF NOT EXISTS forensic_db.conn_stats (
+    time_       DateTime64(9, 'UTC'),
+    upid        String,
+    namespace   String,
+    pod         String,
+    remote_addr String,
+    remote_port Int64,
+    trace_role  Int64,
+    addr_family Int64,
+    protocol    Int64,
+    ssl         UInt8,
+    conn_open   Int64,
+    conn_close  Int64,
+    conn_active Int64,
+    bytes_sent  Int64,
+    bytes_recv  Int64,
+    hostname    String,
+    event_time  DateTime64(3, 'UTC')
+) ENGINE = MergeTree()
+  PARTITION BY toYYYYMM(event_time)
+  ORDER BY (hostname, event_time);
+
 -- ============================================================================
 -- adaptive_attribution — operator's only write target in ClickHouse.
 --


### PR DESCRIPTION
## Why
conn_stats is the only forensic table AE **writes** but did **not ship** in its embedded `schema.sql` (absent from schema.sql + KnownTables + PixieTables). aeprod4's runtime requires it (`VerifyPixieSchema`) → fatal CrashLoopBackOff on **every fresh PG**, repeatedly hand-patched out-of-band. AE is the single source of truth for its table DDL — it belongs here.

## What
- `schema.sql`: `CREATE TABLE forensic_db.conn_stats` — columns mirror pixie `src/stirling/.../conn_stats_table.h` + AE's namespace/pod/hostname/event_time convention (MergeTree, ORDER BY (hostname,event_time)).
- `ddl.go`: register conn_stats in `KnownTables` + `PixieTables()`.
- `ddl_test.go`: conn_stats now KNOWN — unknown-table example swapped to `process_stats`.

## Effect
AE creates conn_stats on every deploy → ends the recurring fresh-PG crashloop, deletes the out-of-band stopgap. Build the next AE image (aeprod5). Fixes entlein/dx#43; unblocks entlein/dx#27.

NB: `entlein/adaptive-write-perf` has the same gap (0 conn_stats) — same patch applies there if it's a separate build base.

## Test
`go test ./.../adaptive_export/internal/clickhouse/...` green (every KnownTable incl conn_stats extracts a valid CREATE TABLE).

/kind bug