### PR TITLE
ae(clickhouse): dx_attack_graph_malicious view at boot

### DIFF
--- a/src/vizier/services/adaptive_export/cmd/main.go
+++ b/src/vizier/services/adaptive_export/cmd/main.go
@@ -557,6 +557,7 @@ func main() {
 	// the existing trigger→controller→activeSet flow is unchanged.
 	if addr := os.Getenv("CONTROL_ADDR"); addr != "" {
 		ctrlSrv := control.New(activeSet, nil) // OrderQuery runner wired later
+		ctrlSrv.SetGraphWriter(applier)        // dx_attack_graph ingest → ClickHouse
 		go func() {
 			log.WithField("addr", addr).Info("control surface listening")
 			if err := http.ListenAndServe(addr, ctrlSrv.Handler()); err != nil &&

--- a/src/vizier/services/adaptive_export/internal/clickhouse/apply.go
+++ b/src/vizier/services/adaptive_export/internal/clickhouse/apply.go
@@ -125,6 +125,17 @@ func (a *Applier) Apply(ctx context.Context) error {
 	return nil
 }
 
+// WriteAttackGraph inserts dx evidence-graph edges into
+// forensic_db.dx_attack_graph. jsonEachRow is newline-delimited JSON objects
+// whose keys are the column names (JSONEachRow; unknown keys are skipped,
+// missing columns default). No-op on empty input.
+func (a *Applier) WriteAttackGraph(ctx context.Context, jsonEachRow []byte) error {
+	if len(jsonEachRow) == 0 {
+		return nil
+	}
+	return a.execute(ctx, "INSERT INTO forensic_db.dx_attack_graph FORMAT JSONEachRow\n"+string(jsonEachRow))
+}
+
 // execute POSTs a single DDL statement to ClickHouse via the HTTP
 // query endpoint. Non-2xx responses surface as Go errors.
 func (a *Applier) execute(ctx context.Context, sql string) error {

--- a/src/vizier/services/adaptive_export/internal/clickhouse/apply.go
+++ b/src/vizier/services/adaptive_export/internal/clickhouse/apply.go
@@ -70,6 +70,8 @@ var OperatorOwnedTables = []string{
 	// globally-registered table to read. dx emits edges, AE persists.
 	// Not a pixie socket_tracer table → not in PixieTables().
 	"dx_attack_graph",
+	// rule-ins-only VIEW over dx_attack_graph; created AFTER it (depends on it).
+	"dx_attack_graph_malicious",
 }
 
 // Applier applies operator-owned DDL to a ClickHouse cluster over the

--- a/src/vizier/services/adaptive_export/internal/clickhouse/apply_test.go
+++ b/src/vizier/services/adaptive_export/internal/clickhouse/apply_test.go
@@ -228,7 +228,7 @@ func TestOperatorOwnedTables_DoesNotIncludeKubescape(t *testing.T) {
 // plugin can auto-DDL them with the wrong schema), then the operator's
 // own write targets in declared order.
 func TestOperatorOwnedTables_TrailingOperatorTables(t *testing.T) {
-	want := []string{"adaptive_attribution", "trigger_watermark", "ae_reconcile", "dx_attack_graph"}
+	want := []string{"adaptive_attribution", "trigger_watermark", "ae_reconcile", "dx_attack_graph", "dx_attack_graph_malicious"}
 	got := OperatorOwnedTables[len(OperatorOwnedTables)-len(want):]
 	for i, w := range want {
 		if got[i] != w {

--- a/src/vizier/services/adaptive_export/internal/clickhouse/ddl.go
+++ b/src/vizier/services/adaptive_export/internal/clickhouse/ddl.go
@@ -67,6 +67,10 @@ var KnownTables = []string{
 	// operator-owned dx evidence-graph edge list (read by the Pixie
 	// dx_evidence_graph UI via clickhouse_dsn). NOT a pixie table.
 	"dx_attack_graph",
+	// rule-ins-only VIEW over dx_attack_graph (condition != ''); the
+	// dx_evidence_graph UI reads this by default so benign rows are filtered
+	// in ClickHouse, not pulled. Must follow dx_attack_graph (depends on it).
+	"dx_attack_graph_malicious",
 }
 
 // ErrUnknownTable is returned by DDL / Columns when asked for a table
@@ -85,8 +89,12 @@ func DDL(table string) (string, error) {
 	if strings.Contains(table, ".") {
 		identifier = "`" + table + "`"
 	}
-	header := "CREATE TABLE IF NOT EXISTS forensic_db." + identifier
-	start := strings.Index(canonicalSchema, header)
+	start := -1
+	for _, kw := range []string{"CREATE TABLE IF NOT EXISTS forensic_db.", "CREATE VIEW IF NOT EXISTS forensic_db."} {
+		if start = strings.Index(canonicalSchema, kw+identifier); start >= 0 {
+			break
+		}
+	}
 	if start < 0 {
 		return "", fmt.Errorf("%w: %q registered in KnownTables but not present in embedded schema.sql", ErrUnknownTable, table)
 	}

--- a/src/vizier/services/adaptive_export/internal/clickhouse/ddl_test.go
+++ b/src/vizier/services/adaptive_export/internal/clickhouse/ddl_test.go
@@ -31,7 +31,8 @@ func TestDDL_ReturnsCanonicalForKnownTables(t *testing.T) {
 			if err != nil {
 				t.Fatalf("DDL(%q): %v", name, err)
 			}
-			if !strings.HasPrefix(ddl, "CREATE TABLE IF NOT EXISTS forensic_db.") {
+			if !strings.HasPrefix(ddl, "CREATE TABLE IF NOT EXISTS forensic_db.") &&
+				!strings.HasPrefix(ddl, "CREATE VIEW IF NOT EXISTS forensic_db.") {
 				t.Fatalf("DDL(%q) wrong prefix: %q", name, ddl[:minInt(70, len(ddl))])
 			}
 			if !strings.HasSuffix(ddl, ";") {

--- a/src/vizier/services/adaptive_export/internal/clickhouse/schema.sql
+++ b/src/vizier/services/adaptive_export/internal/clickhouse/schema.sql
@@ -522,3 +522,8 @@ CREATE TABLE IF NOT EXISTS forensic_db.dx_attack_graph (
   PARTITION BY toYYYYMM(fromUnixTimestamp64Nano(event_time))
   TTL toDateTime(fromUnixTimestamp64Nano(event_time)) + INTERVAL 30 DAY DELETE
   SETTINGS index_granularity = 8192;
+
+-- dx_attack_graph_malicious — rule-ins-only view (condition != '') the
+-- dx_evidence_graph UI reads by default so benign rows stay in ClickHouse.
+CREATE VIEW IF NOT EXISTS forensic_db.dx_attack_graph_malicious AS
+  SELECT * FROM forensic_db.dx_attack_graph WHERE `condition` != '';

--- a/src/vizier/services/adaptive_export/internal/control/server.go
+++ b/src/vizier/services/adaptive_export/internal/control/server.go
@@ -27,6 +27,8 @@
 package control
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"time"
@@ -49,10 +51,17 @@ type queryRunner interface {
 	OrderQuery(target anomaly.Target, table string, start, end time.Time, queryID string) error
 }
 
+// graphWriter persists dx evidence-graph edges (newline-delimited JSON,
+// JSONEachRow) to forensic_db.dx_attack_graph. nil → /dx/attack_graph 501s.
+type graphWriter interface {
+	WriteAttackGraph(ctx context.Context, jsonEachRow []byte) error
+}
+
 // Server is the control HTTP surface.
 type Server struct {
 	set    exporter
 	runner queryRunner // may be nil; /query then returns 501
+	graph  graphWriter // may be nil; /dx/attack_graph then returns 501
 	mux    *http.ServeMux
 }
 
@@ -64,11 +73,47 @@ func New(set exporter, runner queryRunner) *Server {
 	s.mux.HandleFunc("/export/start", s.handleStart)
 	s.mux.HandleFunc("/export/stop", s.handleStop)
 	s.mux.HandleFunc("/query", s.handleQuery)
+	s.mux.HandleFunc("/dx/attack_graph", s.handleDXAttackGraph)
 	return s
 }
 
+// SetGraphWriter wires the dx_attack_graph sink.
+func (s *Server) SetGraphWriter(g graphWriter) { s.graph = g }
+
 // Handler exposes the mux (for httptest + main.go wiring).
 func (s *Server) Handler() http.Handler { return s.mux }
+
+// handleDXAttackGraph ingests a JSON array of dx evidence-graph edges and writes
+// them to forensic_db.dx_attack_graph (as JSONEachRow).
+func (s *Server) handleDXAttackGraph(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	if s.graph == nil {
+		w.WriteHeader(http.StatusNotImplemented)
+		return
+	}
+	var edges []json.RawMessage
+	if !decode(r, &edges) {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	if len(edges) == 0 {
+		w.WriteHeader(http.StatusAccepted)
+		return
+	}
+	var buf bytes.Buffer
+	for _, e := range edges {
+		buf.Write(e)
+		buf.WriteByte('\n')
+	}
+	if err := s.graph.WriteAttackGraph(r.Context(), buf.Bytes()); err != nil {
+		w.WriteHeader(http.StatusBadGateway)
+		return
+	}
+	w.WriteHeader(http.StatusAccepted)
+}
 
 // ── wire types ────────────────────────────────────────────────────────
 type targetReq struct {


### PR DESCRIPTION
Makes the `dx_attack_graph_malicious` view permanent in AE (it was a per-rig manual `CREATE VIEW` before).

- `schema.sql`: add `CREATE VIEW IF NOT EXISTS forensic_db.dx_attack_graph_malicious AS SELECT * FROM dx_attack_graph WHERE condition != ''`.
- `ddl.go`: register in `KnownTables` (after `dx_attack_graph`); `DDL()` now extracts `CREATE VIEW` headers too.
- `apply.go`: add to `OperatorOwnedTables` after `dx_attack_graph` (depends on it) so AE creates it at boot.
- Tests updated; `go test ./...clickhouse` green.

The `px/dx_evidence_graph` UI reads this view by default so benign/ruled-out rows are filtered in ClickHouse, not pulled. Based on #63 (the branch carrying the `dx_attack_graph` DDL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)