### PR TITLE
ci(codeql): fix go-analysis runner label (was queuing forever)

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 jobs:
   analyze-go:
-    runs-on: oracle-16cpu-64gb-x86-64
+    runs-on: oracle-vm-16cpu-64gb-x86-64
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
The CodeQL **go** job used `oracle-16cpu-64gb-x86-64` (nonexistent label on this repo) → queued **12h+/16h+** forever, auto-cancelling at the 24h cap. python/javascript already use `oracle-vm-16cpu-64gb-x86-64`; this aligns go. Cancelled the two stuck runs (27917413327, 27911584113).

Context: this is what looked like 'AE aeprod20 hung 12h' — but the **aeprod20 release itself succeeded** (Build Release ✓ ~70min, image `0.14.19-aeprod20` + GH release published 22:26). The 12h hang was this codeql go-job, unrelated to the release.