### PR TITLE
fix(dx_evidence_graph): coalesce node identity to pod→service→IP (don't collapse empty-pod peers)

### DIFF
--- a/src/pxl_scripts/px/dx_evidence_graph/dx_evidence_graph.pxl
+++ b/src/pxl_scripts/px/dx_evidence_graph/dx_evidence_graph.pxl
@@ -19,7 +19,19 @@ import px
 
 def dx_attack_graph(start_time: str, clickhouse_dsn: str, table: str):
     df = px.DataFrame(table, clickhouse_dsn=clickhouse_dsn, start_time=start_time)
-    return df[['requestor_pod', 'responder_pod',
+    # Node identity: pod, else service, else IP. Edges whose peer is an IP or a
+    # non-pod entity (the k8s API server, an external endpoint, a consulted
+    # socket) have an empty *_pod; keying the graph on *_pod alone collapses ALL
+    # of them into one bogus "" node. Coalesce so each distinct peer is its own
+    # node — same idiom Pixie's net_flow_graph uses (px.select(src=='', src_ip, src)).
+    df.requestor = px.select(df.requestor_pod == '',
+                             px.select(df.requestor_service == '', df.requestor_ip, df.requestor_service),
+                             df.requestor_pod)
+    df.responder = px.select(df.responder_pod == '',
+                             px.select(df.responder_service == '', df.responder_ip, df.responder_service),
+                             df.responder_pod)
+    return df[['requestor', 'responder',
+               'requestor_pod', 'responder_pod',
                'requestor_service', 'responder_service',
                'requestor_ip', 'responder_ip',
                'weight', 'max_severity', 'confidence',

--- a/src/pxl_scripts/px/dx_evidence_graph/vis.json
+++ b/src/pxl_scripts/px/dx_evidence_graph/vis.json
@@ -40,8 +40,8 @@
       "displaySpec": {
         "@type": "types.px.dev/px.vispb.Graph",
         "adjacencyList": {
-          "fromColumn": "requestor_pod",
-          "toColumn": "responder_pod"
+          "fromColumn": "requestor",
+          "toColumn": "responder"
         },
         "edgeWeightColumn": "weight",
         "edgeColorColumn": "max_severity",


### PR DESCRIPTION
The `dx_evidence_graph` Graph widget keys nodes on `requestor_pod`/`responder_pod`. Edges whose peer is **not a pod** — the k8s API server (`responder_service`), external/IP endpoints, the new consulted-socket edges (`responder_ip`) — have an **empty** `*_pod`, so they ALL collapse into a single bogus `""` node, merging unrelated peers.

**Fix:** coalesce node identity to **pod → service → IP** (the same idiom `net_flow_graph` uses, `px.select(src==, src_ip, src)`), and point `adjacencyList.fromColumn`/`toColumn` at the coalesced `requestor`/`responder` columns. Raw `*_pod`/`*_service`/`*_ip` are still returned for hover.

**Validated live** (`px run` against `forensic_db`): `control-plane → k8s-apiserver`; the 5 consulted sockets resolve to 5 distinct IPs (`10.43.143.34`, `10.42.0.1`, `::1`, `127.0.0.1`, `10.42.0.43`) instead of one merged node.

Pairs with entlein/dx#87 (the consulted-evidence edges, which is what surfaced the empty-pod collapse).

🤖 Generated with [Claude Code](https://claude.com/claude-code)