### PR TITLE
feat(ae-control): TLS on the control surface (CONTROL_TLS)

### DIFF
--- a/k8s/vizier/bootstrap/adaptive_export_deployment.yaml
+++ b/k8s/vizier/bootstrap/adaptive_export_deployment.yaml
@@ -88,6 +88,13 @@ spec:
         #   value: "changeme-ingest"
         # - name: CLICKHOUSE_DATABASE
         #   value: "forensic_db"
+        # TLS for the control surface (CONTROL_TLS=true). server.crt/key from the
+        # same service-tls-certs secret the broker/PEM use; without this the dx
+        # bearer JWT crosses the CNI in cleartext. Harmless when control is off.
+        volumeMounts:
+        - name: certs
+          mountPath: /certs
+          readOnly: true
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -95,6 +102,10 @@ spec:
             - ALL
           seccompProfile:
             type: RuntimeDefault
+      volumes:
+      - name: certs
+        secret:
+          secretName: service-tls-certs
       securityContext:
         runAsUser: 10100
         runAsGroup: 10100

--- a/src/vizier/services/adaptive_export/cmd/main.go
+++ b/src/vizier/services/adaptive_export/cmd/main.go
@@ -600,8 +600,27 @@ func main() {
 		}
 		go func() {
 			log.WithField("addr", addr).Info("control surface listening")
-			if err := httpSrv.ListenAndServe(); err != nil &&
-				err != http.ErrServerClosed {
+			// CONTROL_TLS=true → serve TLS so the bearer JWT + control payloads
+			// don't cross the CNI in cleartext (auth without TLS leaks the token).
+			// Cert/key from the service-tls-certs secret the broker/PEM already use
+			// (mounted /certs); dx skip-verifies. Default-OFF for incremental rollout.
+			var err error
+			if os.Getenv("CONTROL_TLS") == "true" {
+				cert := os.Getenv("CONTROL_TLS_CERT")
+				if cert == "" {
+					cert = "/certs/server.crt"
+				}
+				key := os.Getenv("CONTROL_TLS_KEY")
+				if key == "" {
+					key = "/certs/server.key"
+				}
+				log.WithField("cert", cert).Info("control surface: TLS ENABLED")
+				err = httpSrv.ListenAndServeTLS(cert, key)
+			} else {
+				log.Warn("control surface: TLS DISABLED — bearer JWT crosses the CNI in cleartext (set CONTROL_TLS=true)")
+				err = httpSrv.ListenAndServe()
+			}
+			if err != nil && err != http.ErrServerClosed {
 				log.WithError(err).Error("control surface stopped")
 			}
 		}()


### PR DESCRIPTION
## Why
Wire audit (tcpdump on dx→AE :9100) caught **720 cleartext `Authorization: Bearer eyJ…` JWTs in 70s** — the #68 control-surface auth token crosses the CNI in **plaintext** (AE_CONTROL_ADDR is a ClusterIP svc over http). Sniffable + replayable. **Auth without TLS is half a control.**

## What
`CONTROL_TLS=true` → the control surface serves TLS (`httpSrv.ListenAndServeTLS`) with `server.crt`/`server.key` from the **service-tls-certs** secret the broker/PEM already use (verified present in `pl`). dx skip-verifies (entlein/dx#88). Default-OFF, symmetric to `CONTROL_REQUIRE_AUTH` — safe incremental rollout.

- `adaptive_export_deployment.yaml`: mounts service-tls-certs at `/certs`.
- ALPN: `ListenAndServeTLS` offers h2+http/1.1; dx's net/http client speaks http/1.1 over TLS — negotiates cleanly.

## Stacking
Based on `ae-followup-auth` (#68). Rollout: `CONTROL_REQUIRE_AUTH=true` + `CONTROL_TLS=true` together, dx `AE_CONTROL_ADDR`→`https://`.

## Validation
Being tested now on a live PG (one image change at a time, NFRs + tcpdump confirming the :9100 exchange — incl. the auth bearer — is encrypted end-to-end). Evidence to follow.