### PR TITLE
Remove k8s/ directory pins with cert-manager changes upstreamed

### DIFF
--- a/tools/private/copybara/copy.bara.sky
+++ b/tools/private/copybara/copy.bara.sky
@@ -34,7 +34,13 @@ ignored_dirs = [
     ".github/workflows/trivy_images.yaml",
     "DEVELOPMENT.md", # Should be moved to a fork only file
     "ci/github/bazelrc",                           # fork-specific bazelrc REPO_URL
-    "k8s/**",                          # cert-manager support (upstream)
+    # The k8s cloud/vizier cert-manager changes are upstreamed, so the tree is no
+    # longer frozen. Only the files below keep intentional fork-only divergence and
+    # stay pinned; fork-only k8s additions are protected via fork_only_files below.
+    "k8s/cloud/dev/plugin_db_updater_job.yaml",      # fork PL_PLUGIN_REPO override
+    "k8s/cloud/overlays/plugin_job/plugin_job.yaml", # fork PL_PLUGIN_REPO override
+    "k8s/vizier/BUILD.bazel",                        # fork adaptive_export image entry
+    "k8s/cloud/overlays/exposed_services_traefik/**", # To be upstreamed
     "scripts/create_cloud_secrets.sh", # cert-manager support (upstream)
     "skaffold/**",
     "bazel/repositories.bzl", # to be upstreamed


### PR DESCRIPTION
Summary: Remove `k8s/` directory pins with cert-manager changes upstreamed

This removes the `k8s/` directory pin that was protected the cert-manager changes upstreamed in https://github.com/pixie-io/pixie/commit/77e8d9e04a7f9706ca48f4d44adc7edbb9bc69de and https://github.com/pixie-io/pixie/commit/7622689973b118d71a5563e891c44cbc25101aeb.

Relevant Issues: N/A

Type of change: /kind cleanup

Test Plan: Will watch the next copybara sync to verify it merges properly