### PR TITLE
skaffold(cloud): add additive cockpit profile (upstream convention)

### DIFF
--- a/skaffold/skaffold_cloud.yaml
+++ b/skaffold/skaffold_cloud.yaml
@@ -152,3 +152,13 @@ profiles:
     path: /manifests/kustomize/paths
     value:
     - k8s/cloud/public/base
+# Fork profile: deploy the k8sstormcenter cloud overlay (cockpit). Additive —
+# it does not alter the upstream profiles above, mirroring the `public`
+# pattern. Invoke with `-p cockpit`. The kustomize dir is restored by PR #72
+# at private/cockpit/.
+- name: cockpit
+  patches:
+  - op: replace
+    path: /manifests/kustomize/paths
+    value:
+    - private/cockpit


### PR DESCRIPTION
## What

Adds a `cockpit` profile to `skaffold/skaffold_cloud.yaml` **additively**, following upstream skaffold conventions.

```yaml
- name: cockpit
  patches:
  - op: replace
    path: /manifests/kustomize/paths
    value:
    - private/cockpit
```

## Why this shape

The fork's current cockpit deploy (on the PR-68 branch) **replaces** all eight upstream profiles (`minikube/dev/ory_auth/ory_auth_prod/staging/testing/prod/public`) with a single `cockpit` profile and drops `--action_env=GOOGLE_APPLICATION_CREDENTIALS`. That diverges hard from upstream and makes the file painful to reconcile.

This PR instead keeps every upstream profile and `.common_bazel_args` untouched and appends `cockpit` as one more profile, mirroring the `public` pattern — a minimal, upstream-friendly diff (+10 lines).

## Dependencies & the deployment-pipeline change

- **Deploy invocation:** the fork cloud is now deployed with `skaffold run -f skaffold/skaffold_cloud.yaml -p cockpit` (previously the fork profile was the only one, so no `-p` was needed). **Whatever runs the actual cloud deploy must be updated to pass `-p cockpit`.** No CI workflow in this repo invokes `skaffold_cloud.yaml` (only `DEVELOPMENT.md` references it), so that pipeline is external/lab — out of scope for this PR.
- **Kustomize target:** `private/cockpit/` is restored by **PR #72**; this profile points there. Merge #72 first (or together).
- **Copybara:** `skaffold/**` is already in `ignored_dirs`, so the mirror won't touch this.

## Draft

Marked draft because it's coupled to the external deployment-pipeline change above and the `-p cockpit` wiring. The profile shape (additive, path `private/cockpit`, keeping `GOOGLE_APPLICATION_CREDENTIALS`) is a proposal — easy to adjust.

---

Summary: Add an additive 'cockpit' profile to skaffold/skaffold_cloud.yaml (keeps all upstream profiles), replacing the fork's replace-all divergence.

Type of change: /kind cleanup

Test Plan: arc lint clean; +10-line additive diff; deploy via 'skaffold run -f skaffold/skaffold_cloud.yaml -p cockpit'.
