### PR TITLE
lint: fix arc-lint breakage on main (suite exclude + skaffold indent + copy.bara dup)

### DIFF
--- a/.arclint
+++ b/.arclint
@@ -21,6 +21,7 @@
     "(^src/operator/client/versioned/)",
     "(^src/operator/apis/px.dev/v1alpha1/zz_generated.deepcopy.go)",
     "(^src/e2e_test/adaptive_export_loadtest/tools/loadgen/)",
+    "(^src/e2e_test/adaptive_export_loadtest/suite/)",
     "(^src/stirling/bpf_tools/bcc_bpf/system-headers)",
     "(^src/stirling/mysql/testing/.*\\.json$)",
     "(^src/stirling/obj_tools/testdata/go/test_go_binary.go)",

--- a/src/e2e_test/adaptive_export_loadtest/skaffold.yaml
+++ b/src/e2e_test/adaptive_export_loadtest/skaffold.yaml
@@ -22,15 +22,15 @@ kind: Config
 metadata:
   name: e2e-nonpixie
 requires:
-  - git:
-      repo: https://github.com/k8sstormcenter/soc
-      path: skaffold.yaml
-      ref: main
-    configs:
-      - soc-stack
-  - git:
-      repo: https://github.com/k8sstormcenter/bob
-      path: example/java-poc/skaffold.yaml
-      ref: main
-    configs:
-      - java-poc-apps
+- git:
+    repo: https://github.com/k8sstormcenter/soc
+    path: skaffold.yaml
+    ref: main
+  configs:
+  - soc-stack
+- git:
+    repo: https://github.com/k8sstormcenter/bob
+    path: example/java-poc/skaffold.yaml
+    ref: main
+  configs:
+  - java-poc-apps

--- a/tools/private/copybara/copy.bara.sky
+++ b/tools/private/copybara/copy.bara.sky
@@ -107,7 +107,6 @@ ignored_dirs = [
     "src/vizier/services/agent/pem/pem_main.cc",
     "src/vizier/services/agent/pem/pem_manager.cc",
     "src/vizier/services/agent/pem/pem_manager.h",
-    "src/vizier/funcs/md_udtfs/**", # Clickhouse UDTF changes "src/vizier/services/agent/shared/manager/BUILD.bazel", # ASAN build changes. Likely to be upstreamed
     "src/vizier/services/cloud_connector/bridge/**", # should be made generic and upstreamed
     "src/vizier/services/metadata/metadatapb/BUILD.bazel",
     "src/vizier/services/metadata/local/**", # clickhouse testing changes, likely can be removed


### PR DESCRIPTION
Main's lint broke after #68/#83 merged the `adaptive_export_loadtest` tree. Three fixes:

1. **`.arclint`** — exclude the `src/e2e_test/adaptive_export_loadtest/suite/` nested go module (`aeloadsuite`). golangci-lint typecheck-fails on it from the root module (`main module (px.dev/pixie) does not contain package …/suite`). The sibling `tools/loadgen/` was already excluded; this mirrors it.
2. **`src/e2e_test/adaptive_export_loadtest/skaffold.yaml`** — reindent the `requires:` block to `indent-sequences: false` (yamllint: expected 0/4, was 2/6). yamllint clean now.
3. **`tools/private/copybara/copy.bara.sky`** — drop a malformed duplicate list line (`md_udtfs/**` + `shared/manager/BUILD.bazel` concatenated behind a comment) that rode in via #83; both paths are already listed correctly above it.

Verified: `yamllint` clean on skaffold.yaml; the `.arclint` exclude structurally removes the golangci-lint typecheck failure on the nested module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)