### PR TITLE
fix(pem): default direct_query_enabled=true so dx pemdirect always works

### DIFF
--- a/src/vizier/services/agent/pem/DIRECT_QUERY_CONTRACT.md
+++ b/src/vizier/services/agent/pem/DIRECT_QUERY_CONTRACT.md
@@ -38,11 +38,16 @@ The two differences for the real PEM:
 
 | flag / env                          | default | meaning                                            |
 |-------------------------------------|---------|----------------------------------------------------|
-| `--direct_query_enabled` / `PL_PEM_DIRECT_QUERY_ENABLED` | `false` | master switch; when false the port is never opened |
+| `--direct_query_enabled` / `PL_PEM_DIRECT_QUERY_ENABLED` | `true` (fork) | master switch; when false the port is never opened |
 | `--direct_query_port` / `PL_PEM_DIRECT_QUERY_PORT`       | `50305` | gRPC listen port for the direct-query service      |
 | `--direct_query_jwt_signing_key` / `PL_JWT_SIGNING_KEY`  | `""`    | HMAC key the bearer JWT must verify against         |
 
-Default-off so existing PEM deployments are byte-for-byte unchanged until opted in.
+Default-**on** in this k8sstormcenter fork: dx queries the node-local direct-query
+server (`DX_BENCH=pemdirect`, :50305) and the vizier deploy templates do not reliably
+set `PL_PEM_DIRECT_QUERY_ENABLED` (the `customPEMFlags` Helm path is often left unset),
+so a `false` default silently leaves :50305 unbound and dx's pemdirect gets
+`connection refused`. Opt out at runtime with `PL_PEM_DIRECT_QUERY_ENABLED=false`, or
+compile it out with `--//src/vizier/services/agent/pem:direct_query=disabled`.
 
 ## Auth contract
 

--- a/src/vizier/services/agent/pem/pem_manager.cc
+++ b/src/vizier/services/agent/pem/pem_manager.cc
@@ -38,9 +38,14 @@
 // entirely. Operators who do not want direct-query available even as a
 // disabled-by-default option get a binary with zero direct-query bytes.
 #ifndef PX_PEM_DIRECT_QUERY_DISABLED
-DEFINE_bool(direct_query_enabled, gflags::BoolFromEnv("PL_PEM_DIRECT_QUERY_ENABLED", false),
+DEFINE_bool(direct_query_enabled, gflags::BoolFromEnv("PL_PEM_DIRECT_QUERY_ENABLED", true),
             "If true, expose VizierService::ExecuteScript directly from this PEM. "
-            "Default false; existing PEM deploys see no behavior change.");
+            "Default true in this fork: dx queries the node-local direct-query server "
+            "at :50305 (DX_BENCH=pemdirect), and the deploy templates do not reliably "
+            "set PL_PEM_DIRECT_QUERY_ENABLED (the customPEMFlags path is often unset), "
+            "so a false default silently leaves :50305 unbound. Set "
+            "PL_PEM_DIRECT_QUERY_ENABLED=false to opt out at runtime, or build with "
+            "--//src/vizier/services/agent/pem:direct_query=disabled to compile it out.");
 DEFINE_int32(direct_query_port, gflags::Int32FromEnv("PL_PEM_DIRECT_QUERY_PORT", 50305),
              "gRPC listen port for the direct-query service when "
              "--direct_query_enabled=true.");


### PR DESCRIPTION
Summary: dx (DX_BENCH=pemdirect) queries the PEM's node-local direct-query gRPC server on :50305 (entlein/dx#29). On deployed rigs that port is never bound, so dx logs `pempdirect ExecuteScript failed: connection refused` (32 fails / 60s observed on rig 6a5c8f89), which blocks the log4shell workup (pull_conn_endpoints / pull_pgsql_queries / pull_dns_queries / pull_http_semantics) and therefore the malignant dx_evidence_graph edges. RCA: `pem_manager.cc` gates the server on `PL_PEM_DIRECT_QUERY_ENABLED`, which defaults false; and `vizier_yamls.go`'s PEM env patch injects `PL_PEM_ENV_VAR_PLACEHOLDER`, an explicit no-op placeholder — real PEM flags are only settable via Helm `.Values.customPEMFlags`, which the vizier deploy on these rigs leaves unset. So the false default wins and :50305 never binds. Fix: flip the runtime default to true (this fork exists for dx, which always needs the node-local direct-query server). Opt out at runtime with `PL_PEM_DIRECT_QUERY_ENABLED=false`, or compile out with `--//src/vizier/services/agent/pem:direct_query=disabled`. `DIRECT_QUERY_CONTRACT.md` updated.

Relevant Issues: entlein/dx#29

Type of change: /kind bug

Test Plan: @build-agent please build the vizier image set (PEM) from this branch. I will `kubectl set image` the new vizier-pem onto rig 6a5c8f89 and re-run the exact medical-rc1 end-to-end test (pg traffic + one log4shell disease fire), expecting pemdirect to stop refusing, :50305 to bind, and the backend malignant rule-in + dx_evidence_graph edges to be driven by the live pull_* workup. Before/after evidence saved via biz/PoC/OTel/save_evidence.sh. No unit test asserts the previous false default — direct_query_server_test.cc toggles the flag explicitly.

Changelog Message:
```release-note
The PEM node-local direct-query server (PL_PEM_DIRECT_QUERY_ENABLED, port :50305) now defaults to enabled in the k8sstormcenter fork so dx pemdirect works out of the box. Set PL_PEM_DIRECT_QUERY_ENABLED=false to opt out at runtime.
```
