### PR TITLE
fix(ui): restore workspace-status export whitelist in ui.bzl

### DIFF
--- a/bazel/ui.bzl
+++ b/bazel/ui.bzl
@@ -69,11 +69,12 @@ def _pl_webpack_library_impl(ctx):
     if ctx.attr.stamp:
         # This is some truly shady stuff. The stamping on genrules just makes this file
         # available, but does not apply it to the environment. We parse out the file
-        # and apply it to the environment here. Hopefully,
-        # no special characters/spaces/quotes in the results ...
+        # and apply it to the environment here. Only the keys the UI actually reads are
+        # exported: other status values may contain spaces, which the shell would split
+        # into bare words and `export` would then reject as invalid identifiers.
         env_cmds = [
-            '$(sed -E "s/^([A-Za-z_]+)\\s*(.*)/export \\1=\\2/g" "{}")'.format(ctx.info_file.path),
-            '$(sed -E "s/^([A-Za-z_]+)\\s*(.*)/export \\1=\\2/g" "{}")'.format(ctx.version_file.path),
+            '$(sed -E -n "s/^(STABLE_BUILD_TAG|BUILD_TIMESTAMP)\\s+(.*)/export \\1=\\2/p" "{}")'.format(ctx.info_file.path),
+            '$(sed -E -n "s/^(STABLE_BUILD_TAG|BUILD_TIMESTAMP)\\s+(.*)/export \\1=\\2/p" "{}")'.format(ctx.version_file.path),
         ]
         all_files.append(ctx.info_file)
         all_files.append(ctx.version_file)


### PR DESCRIPTION
Summary: Commit 53d09cc8d replaced the narrow `sed -E -n ... /p` whitelist in `bazel/ui.bzl` with an unfiltered `sed -E ... /g` that matches every `[A-Za-z_]+` key, so all Bazel workspace-status variables get exported into the webpack action instead of only the two the UI reads. Any status value containing whitespace is word-split by the shell, and `export` then rejects the fragments as invalid identifiers, which breaks the `&&` chain and fails `//src/ui:ui_bundle`. This took down the cloud release build (run 29753584724), which errored with `export: '20': not a valid identifier` and three similar lines rather than any actual webpack or TypeScript problem. The last successful cloud release, v0.0.17-pre-v0.0, predates 53d09cc8d and shows zero such errors; `bazel/ui.bzl` is the only build-related file changed between that tag and current main. Since `src/ui/src/utils/env.tsx` consumes only `STABLE_BUILD_TAG` and `BUILD_TIMESTAMP`, narrowing back to those two keys is sufficient and restores the exact behaviour of the last known-good release build. The rest of 53d09cc8d is left intact.

Test Plan: Reproduced the failure against a simulated `stable-status.txt` containing a space-bearing value and confirmed the pre-fix expression emits the same `not a valid identifier` errors seen in CI, while the restored expression exports `STABLE_BUILD_TAG` and `BUILD_TIMESTAMP` cleanly and exits zero. `arc lint` is clean. Full verification is the release workflow itself, which should now get past `//src/ui:ui_bundle`.

Type of change: /kind bug

Changelog Message: Fix release build failure caused by exporting Bazel workspace-status values that contain whitespace into the UI webpack action.