### PR TITLE
k8s(ae): pin adaptive_export to 0.14.19-aeprod86

### DIFF
--- a/k8s/vizier/adaptive_export/kustomization.yaml
+++ b/k8s/vizier/adaptive_export/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
   - name: vizier-adaptive_export_image
     newName: ghcr.io/k8sstormcenter/vizier-adaptive_export_image
-    newTag: 0.14.19-aeprod81
+    newTag: 0.14.19-aeprod86


### PR DESCRIPTION
Bumps the AE deploy pin from **aeprod81** (stale by 5 builds) to **aeprod86** (durable, green).

aeprod86 is a strict superset — verified its schema before pinning:
| fix | present |
|---|---|
| order-time dx_ord__ views (empty-panel fix) | 11/11 |
| payload unique_id keys | ✓ |
| phantom dx_* tables removed | ✓ |
| protocol bridges (cql/mongodb/creds_change) | ✓ |
| dx_kubescape_mitre.ts (ORDERS panel) | ✓ (the aeprod86 addition) |

Note: the AE image pin lives here in pixie (`k8s/vizier/adaptive_export/kustomization.yaml`), **not in soc** — soc/skaffold.yaml explicitly does not own `pl`/adaptive_export.